### PR TITLE
[Bug] lefthook의 validation script들에 명시적으로 exit 1 추가

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
         echo "🔍 ========================================="
         echo "🔧 Running ESLint on staged files..."
         echo "🔍 ========================================="
-        pnpm exec eslint {staged_files} --fix
+        pnpm exec eslint {staged_files} --fix || exit 1
         echo "✅ ESLint completed successfully!"
       stage_fixed: true
     prettier:
@@ -16,7 +16,7 @@ pre-commit:
         echo "💅 ========================================="
         echo "🎨 Running Prettier on staged files..."
         echo "💅 ========================================="
-        pnpm exec prettier --write {staged_files}
+        pnpm exec prettier --write {staged_files} || exit 1
         echo "✅ Code formatting completed!"
       stage_fixed: true
     type-check:
@@ -24,7 +24,7 @@ pre-commit:
         echo "🔍 ========================================="
         echo "📝 Running TypeScript type checking..."
         echo "🔍 ========================================="
-        pnpm type-check
+        pnpm type-check || exit 1
         echo "✅ Type checking completed successfully!"
 
 prepare-commit-msg: # 원래는 아예 필요가 없음, 하지만 추후 gitmoji 자동 생성을 위해 남겨둡니다.
@@ -34,7 +34,7 @@ prepare-commit-msg: # 원래는 아예 필요가 없음, 하지만 추후 gitmoj
         echo "📝 ========================================="
         echo "🏷️  Preparing commit message..."
         echo "📝 ========================================="
-        node scripts/prepare-commit-msg.cjs {{1}}
+        node scripts/prepare-commit-msg.cjs {{1}} || exit 1
         echo "✅ Commit message prepared!"
 
 commit-msg:
@@ -44,7 +44,7 @@ commit-msg:
         echo "📋 ========================================="
         echo "🔍 Validating commit message format..."
         echo "📋 ========================================="
-        node scripts/run-commitlint.cjs {{1}}
+        node scripts/run-commitlint.cjs {{1}} || exit 1
         echo "✅ Commit message validation passed!"
 
 pre-rebase:
@@ -54,7 +54,7 @@ pre-rebase:
         echo "🔄 ========================================="
         echo "🧹 Checking repository cleanliness..."
         echo "🔄 ========================================="
-        node scripts/pre-rebase-check.cjs
+        node scripts/pre-rebase-check.cjs || exit 1
         echo "✅ Repository clean check completed!"
 
 pre-push:
@@ -71,7 +71,7 @@ pre-push:
           echo "🔨 ========================================="
           echo "🏗️ Running production build..."
           echo "🔨 ========================================="
-          pnpm build
+          pnpm build || exit 1
           echo "🎉 ========================================="
           echo "✅ Build completed successfully!"
           echo "🚀 Ready to push!"


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.

- Issue #151 

## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

- `|| exit 1` 을 각 script 뒤에 붙여주었습니다

## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.

-

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

-

## 📝 Checklist

- [ ] Reviewer를 추가했나요?
- [ ] Convention을 준수했나요?
