### PR TITLE
[Refactor] on-boarding 전체적인 refactor 및 api 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
+    "@lukemorales/query-key-factory": "^1.3.4",
     "@sentry/nextjs": "^9.42.1",
+    "@tanstack/react-query": "^5.83.0",
     "@wavesurfer/react": "^1.0.11",
     "chart.js": "^4.5.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@lukemorales/query-key-factory':
+        specifier: ^1.3.4
+        version: 1.3.4(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@19.1.0))
       '@sentry/nextjs':
         specifier: ^9.42.1
         version: 9.42.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.4(@babel/core@7.27.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.100.2(esbuild@0.25.5))
+      '@tanstack/react-query':
+        specifier: ^5.83.0
+        version: 5.83.0(react@19.1.0)
       '@wavesurfer/react':
         specifier: ^1.0.11
         version: 1.0.11(react@19.1.0)(wavesurfer.js@7.10.1)
@@ -1238,6 +1244,13 @@ packages:
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
+  '@lukemorales/query-key-factory@1.3.4':
+    resolution: {integrity: sha512-A3frRDdkmaNNQi6mxIshsDk4chRXWoXa05US8fBo4kci/H+lVmujS6QrwQLLGIkNIRFGjMqp2uKjC4XsLdydRw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@tanstack/query-core': '>= 4.0.0'
+      '@tanstack/react-query': '>= 4.0.0'
+
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
@@ -2118,6 +2131,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
+
+  '@tanstack/query-core@5.83.0':
+    resolution: {integrity: sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==}
+
+  '@tanstack/react-query@5.83.0':
+    resolution: {integrity: sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -6991,6 +7012,11 @@ snapshots:
 
   '@kurkle/color@0.3.4': {}
 
+  '@lukemorales/query-key-factory@1.3.4(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@19.1.0))':
+    dependencies:
+      '@tanstack/query-core': 5.83.0
+      '@tanstack/react-query': 5.83.0(react@19.1.0)
+
   '@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -8035,6 +8061,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       postcss: 8.5.6
       tailwindcss: 4.1.11
+
+  '@tanstack/query-core@5.83.0': {}
+
+  '@tanstack/react-query@5.83.0(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.83.0
+      react: 19.1.0
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import '@styles/globals.css';
 
 import Toaster from '@common/components/toast/Toaster/Toaster.client';
 
+import QueryClientProviders from './query-client-providers';
+
 const pretendard = localFont({
   src: '../assets/fonts/pretendard/PretendardVariable.woff2',
   variable: '--font-pretendard',
@@ -26,16 +28,18 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang="ko">
-      <body
-        className={clsx(
-          'scrollbar-page flex min-h-screen flex-col overflow-y-auto',
-          pretendard.variable,
-        )}
-      >
-        {children}
-        <div id="modal" />
-        <Toaster />
-      </body>
+      <QueryClientProviders>
+        <body
+          className={clsx(
+            'scrollbar-page flex min-h-screen flex-col overflow-y-auto',
+            pretendard.variable,
+          )}
+        >
+          {children}
+          <div id="modal" />
+          <Toaster />
+        </body>
+      </QueryClientProviders>
     </html>
   );
 };

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+import QueryClientProviders from '../query-client-providers';
+
 export const metadata: Metadata = {
   title: '온보딩 워크스페이스 생성하기 페이지',
   description:
@@ -11,7 +13,7 @@ const OnboardingLayout = ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
-  return <main>{children}</main>;
+  return <QueryClientProviders>{children}</QueryClientProviders>;
 };
 
 export default OnboardingLayout;

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -13,7 +13,7 @@ const OnboardingLayout = ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
-  return <QueryClientProviders>{children}</QueryClientProviders>;
+  return <main>{children}</main>;
 };
 
 export default OnboardingLayout;

--- a/src/app/query-client-providers.tsx
+++ b/src/app/query-client-providers.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useState } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const QueryClientProviders = ({ children }: { children: React.ReactNode }) => {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+export default QueryClientProviders;

--- a/src/app/workspace/[id]/page.tsx
+++ b/src/app/workspace/[id]/page.tsx
@@ -2,40 +2,12 @@
 
 import { useState } from 'react';
 
-import { FileType } from '@common/types/file-type.enum';
-
 import ImageCta from '@common/components/cta/ImageCta/ImageCta.client';
 import ImageCtaSkeleton from '@common/components/cta/ImageCta/ImageCtaSkeleton';
 import BoxedFile from '@common/components/etc/BoxedFile/BoxedFile.client';
-import { DocumentType } from '@common/components/etc/BoxedFile/BoxedFile.types';
 import BoxedFileSkeleton from '@common/components/etc/BoxedFile/BoxedFileSkelton';
 
-const ctaItems = [
-  { type: FileType.AI_MEETING_MANAGER, onClick: () => console.log('AI') },
-  { type: FileType.SNS_EVENT_ASSISTANT, onClick: () => console.log('SNS') },
-  { type: FileType.TEAM_MOOD_TRACKER, onClick: () => console.log('TEAM') },
-];
-
-// 더미 데이터
-const docTypes: DocumentType[] = [
-  DocumentType.AI_MEETING_MANAGER,
-  DocumentType.SNS_EVENT_ASSISTANT,
-  DocumentType.TEAM_MOOD_TRACKER,
-];
-
-const now = new Date();
-const dummyFiles = Array.from({ length: 5 }, (_, index) => {
-  const date = new Date(now);
-  date.setHours(date.getHours() - index * 4);
-  const title = `${date.getMonth() + 1}월 ${date.getDate()}일 회의록`;
-
-  return {
-    title,
-    lastOpened: date.toISOString(),
-    documentType: docTypes[index % docTypes.length],
-    thumbnailUrl: '',
-  };
-});
+import { ctaItems, dummyFiles } from '@features/on-boarding/mocks/dummy-files';
 
 const WorkSpaceMainPage = () => {
   // 임시 로딩 상태 (실제 프로젝트에서는 API fetch 기준으로 변경)

--- a/src/common/components/inputs/input-invite-member/InputInviteMember/InputInviteMember.client.tsx
+++ b/src/common/components/inputs/input-invite-member/InputInviteMember/InputInviteMember.client.tsx
@@ -81,7 +81,7 @@ const InputInviteMember = ({
       {/* 타이틀 부분 */}
       {title && <span className="text-cap1-rg text-gray-200">{title}</span>}
       {/* 이메일 입력 및 초대 버튼 부분 */}
-      <div className="flex flex-col gap-1">
+      <div className="flex w-full flex-col gap-1">
         <div
           className={clsx(
             'h-min-48pxr rounded-9pxr py-9pxr flex w-full shrink-0 items-center justify-between gap-2.5 px-3.5',

--- a/src/common/constants/query-key.constants.ts
+++ b/src/common/constants/query-key.constants.ts
@@ -1,0 +1,18 @@
+import { createQueryKeyStore } from '@lukemorales/query-key-factory';
+
+// 도메인(기능)별로 키를 그룹화합니다.
+const queryKeys = createQueryKeyStore({
+  workspaces: {
+    // 매개변수가 없는 키는 null로 정의합니다.
+    all: null,
+    // 매개변수가 있는 키는 함수로 정의합니다.
+    detail: (workspaceId: number) => [workspaceId],
+    members: (workspaceId: number) => [workspaceId, 'members'],
+  },
+  // 다른 도메인 추가 가능 - 이후 자신에게 맞는 도메인 이름으로 추가해서 사용 하시면 됩니다.
+  // snsEventAssisant: {
+  //   all: null,
+  // },
+});
+
+export default queryKeys;

--- a/src/common/types/api.types.ts
+++ b/src/common/types/api.types.ts
@@ -1,0 +1,7 @@
+// 모든 API 응답의 기본 구조 정의 interface
+export interface BaseResponseDto<T> {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+}

--- a/src/common/utils/join-url.utils.ts
+++ b/src/common/utils/join-url.utils.ts
@@ -1,0 +1,5 @@
+export const joinURL = (baseURL: string, path: string) => {
+  const trimmedBase = baseURL.replace(/\/+$/, '');
+  const trimmedPath = path.replace(/^\/+/, '');
+  return `${trimmedBase}/${trimmedPath}`;
+};

--- a/src/features/on-boarding/apis/post/create-workspace.ts
+++ b/src/features/on-boarding/apis/post/create-workspace.ts
@@ -1,0 +1,32 @@
+import { defaultApi } from '@lib/fetcher';
+
+import { BaseResponseDto } from '@common/types/api.types';
+
+import {
+  CreateWorkspaceRequestDto,
+  CreateWorkspaceResponseDto,
+} from '@features/on-boarding/types/apis.types';
+
+import { API_ENDPOINTS } from '@features/on-boarding/constants/end-point.constants';
+
+export const createWorkspace = async ({
+  name,
+  image,
+}: CreateWorkspaceRequestDto): Promise<BaseResponseDto<CreateWorkspaceResponseDto>> => {
+  const formData = new FormData();
+  formData.append('name', name);
+  if (image) {
+    formData.append('image', image);
+  }
+
+  const response = await defaultApi<BaseResponseDto<CreateWorkspaceResponseDto>>(
+    API_ENDPOINTS.WORKSPACES,
+    {
+      method: 'POST',
+      body: formData,
+      headers: {},
+    },
+  );
+
+  return response;
+};

--- a/src/features/on-boarding/apis/post/create-workspace.ts
+++ b/src/features/on-boarding/apis/post/create-workspace.ts
@@ -14,9 +14,17 @@ export const createWorkspace = async ({
   image,
 }: CreateWorkspaceRequestDto): Promise<BaseResponseDto<CreateWorkspaceResponseDto>> => {
   const formData = new FormData();
-  formData.append('name', name);
+
+  formData.append('request', JSON.stringify({ title: name }));
+
   if (image) {
     formData.append('image', image);
+  } else {
+    formData.append('image', '');
+  }
+
+  for (const [key, value] of formData.entries()) {
+    console.log(`[FormData] ${key}:`, value);
   }
 
   const response = await defaultApi<BaseResponseDto<CreateWorkspaceResponseDto>>(

--- a/src/features/on-boarding/apis/post/invite-member.ts
+++ b/src/features/on-boarding/apis/post/invite-member.ts
@@ -1,0 +1,19 @@
+import { defaultApi } from '@lib/fetcher';
+
+import { BaseResponseDto } from '@common/types/api.types';
+
+import { InviteMembersRequestDto } from '@features/on-boarding/types/apis.types';
+
+import { API_ENDPOINTS } from '@features/on-boarding/constants/end-point.constants';
+
+export const inviteMembers = async ({
+  workspaceId,
+  emails,
+}: InviteMembersRequestDto): Promise<BaseResponseDto<object>> => {
+  const response = await defaultApi<BaseResponseDto<object>>(API_ENDPOINTS.INVITE_MEMBERS, {
+    method: 'POST',
+    body: JSON.stringify({ workspaceId, emails }),
+  });
+
+  return response;
+};

--- a/src/features/on-boarding/components/OnBoardingImageStep/OnBoardingImageStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingImageStep/OnBoardingImageStep.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { ChangeEvent, useRef, useState } from 'react';
-
 import ChangableWorkspaceImage from '@common/components/ChangableWorkspaceImage/ChangableWorkspaceImage.client';
 import MoveToNextButton from '@common/components/buttons/48px/MoveToNextButton/MoveToNextButton.client';
 import { MoveToNextButtonWidth } from '@common/components/buttons/48px/MoveToNextButton/MoveToNextButton.types';
@@ -9,12 +7,28 @@ import { MoveToNextButtonWidth } from '@common/components/buttons/48px/MoveToNex
 import { useOnboardingActions } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 import { useOnboardingState } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 
+import { useCreateWorkspaceMutation } from '@features/on-boarding/mutations/useCreateWorkspaceMutation';
+
 const OnBoardingImageStep = () => {
   const { setImage, nextStep } = useOnboardingActions();
-  const { name } = useOnboardingState;
+  const { name, image } = useOnboardingState();
+
+  const { mutate } = useCreateWorkspaceMutation();
 
   const handleNext = () => {
-    nextStep();
+    mutate(
+      { name, image },
+      {
+        onSuccess: () => {
+          console.log('워크스페이스 생성 성공!');
+          nextStep();
+        },
+        onError: (error) => {
+          console.error('워크스페이스 생성 실패:', error);
+          alert('워크스페이스 생성에 실패했습니다.');
+        },
+      },
+    );
   };
 
   // 임시
@@ -31,6 +45,7 @@ const OnBoardingImageStep = () => {
         title={name}
         initialPreview={previewUrlFromServer}
         onFileChange={(file) => {
+          console.log('[OnBoardingImageStep] 선택한 이미지 파일:', file);
           setImage(file);
         }}
         className="mb-141pxr"

--- a/src/features/on-boarding/components/OnBoardingImageStep/OnBoardingImageStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingImageStep/OnBoardingImageStep.tsx
@@ -19,7 +19,6 @@ const OnBoardingImageStep = () => {
       { name, image },
       {
         onSuccess: (data) => {
-          console.log('워크스페이스 생성 성공!', data);
           const newWorkspaceId = data?.result?.workspaceId;
 
           setWorkspaceId(newWorkspaceId);
@@ -27,7 +26,6 @@ const OnBoardingImageStep = () => {
         },
         onError: (error) => {
           console.error('워크스페이스 생성 실패:', error);
-          alert('워크스페이스 생성에 실패했습니다.');
         },
       },
     );
@@ -47,7 +45,6 @@ const OnBoardingImageStep = () => {
         title={name}
         initialPreview={previewUrlFromServer}
         onFileChange={(file) => {
-          console.log('[OnBoardingImageStep] 선택한 이미지 파일:', file);
           setImage(file);
         }}
         className="mb-141pxr"

--- a/src/features/on-boarding/components/OnBoardingImageStep/OnBoardingImageStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingImageStep/OnBoardingImageStep.tsx
@@ -4,13 +4,12 @@ import ChangableWorkspaceImage from '@common/components/ChangableWorkspaceImage/
 import MoveToNextButton from '@common/components/buttons/48px/MoveToNextButton/MoveToNextButton.client';
 import { MoveToNextButtonWidth } from '@common/components/buttons/48px/MoveToNextButton/MoveToNextButton.types';
 
+import { useCreateWorkspaceMutation } from '@features/on-boarding/hooks/mutations/useCreateWorkspaceMutation';
 import { useOnboardingActions } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 import { useOnboardingState } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 
-import { useCreateWorkspaceMutation } from '@features/on-boarding/mutations/useCreateWorkspaceMutation';
-
 const OnBoardingImageStep = () => {
-  const { setImage, nextStep } = useOnboardingActions();
+  const { setImage, nextStep, setWorkspaceId } = useOnboardingActions();
   const { name, image } = useOnboardingState();
 
   const { mutate } = useCreateWorkspaceMutation();
@@ -19,8 +18,11 @@ const OnBoardingImageStep = () => {
     mutate(
       { name, image },
       {
-        onSuccess: () => {
-          console.log('워크스페이스 생성 성공!');
+        onSuccess: (data) => {
+          console.log('워크스페이스 생성 성공!', data);
+          const newWorkspaceId = data?.result?.workspaceId;
+
+          setWorkspaceId(newWorkspaceId);
           nextStep();
         },
         onError: (error) => {

--- a/src/features/on-boarding/components/OnBoardingInstaStep/OnBoardingInstaStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingInstaStep/OnBoardingInstaStep.tsx
@@ -9,10 +9,13 @@ import { SkipForNowButtonType } from '@common/components/buttons/diverse-size/Sk
 
 import { OnboardingToastType } from '@features/on-boarding/types/OnboardingToast.types';
 
+import { API_ENDPOINTS } from '@features/on-boarding/constants/end-point.constants';
+
 import {
   useInstagramConnection,
   useOnboardingActions,
   useOnboardingState,
+  useOnboardingWorkspaceId,
 } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 import { useOnboardingToastActions } from '@features/on-boarding/hooks/stores/useOnboardingToastStore';
 
@@ -25,9 +28,7 @@ const OnBoardingInstaStep = () => {
   const isConnected = useInstagramConnection();
   const { setInstagramConnected } = useOnboardingActions();
 
-  const { name, emails, image } = useOnboardingState();
-
-  const workspaceId = 1; // 임시
+  const workspaceId = useOnboardingWorkspaceId();
 
   const handleConnectInstagram = () => {
     // 실제 연동 로직 연결 - 추후
@@ -39,13 +40,12 @@ const OnBoardingInstaStep = () => {
     });
   };
 
-  const handleCreateWorkSpace = () => {
-    console.log('워크스페이스 생성');
-
-    console.log('🔥 상태값 확인용');
-    console.log('name:', name);
-    console.log('emails:', emails);
-    console.log('image:', image);
+  const handleStart = () => {
+    if (workspaceId) {
+      router.push(API_ENDPOINTS.WORKSPACE_DETAIL(workspaceId));
+    } else {
+      alert('워크스페이스 정보가 없습니다. 온보딩을 다시 진행해주세요.');
+    }
   };
 
   return (
@@ -62,7 +62,7 @@ const OnBoardingInstaStep = () => {
       <div className="gap-8pxr flex">
         <SkipForNowButton buttonType={SkipForNowButtonType.SIZE_48} />
 
-        <StartButton onClick={handleCreateWorkSpace} disabled={!isConnected} />
+        <StartButton onClick={handleStart} disabled={!isConnected} />
       </div>
     </div>
   );

--- a/src/features/on-boarding/components/OnBoardingInstaStep/OnBoardingInstaStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingInstaStep/OnBoardingInstaStep.tsx
@@ -14,7 +14,6 @@ import { API_ENDPOINTS } from '@features/on-boarding/constants/end-point.constan
 import {
   useInstagramConnection,
   useOnboardingActions,
-  useOnboardingState,
   useOnboardingWorkspaceId,
 } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 import { useOnboardingToastActions } from '@features/on-boarding/hooks/stores/useOnboardingToastStore';
@@ -44,7 +43,7 @@ const OnBoardingInstaStep = () => {
     if (workspaceId) {
       router.push(API_ENDPOINTS.WORKSPACE_DETAIL(workspaceId));
     } else {
-      alert('워크스페이스 정보가 없습니다. 온보딩을 다시 진행해주세요.');
+      console.log('워크스페이스 정보가 없습니다. 온보딩을 다시 진행해주세요.');
     }
   };
 

--- a/src/features/on-boarding/components/OnBoardingInviteStep/OnBoardingInviteStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingInviteStep/OnBoardingInviteStep.tsx
@@ -10,13 +10,12 @@ import InputInviteMember from '@common/components/inputs/input-invite-member/Inp
 
 import { OnboardingToastType } from '@features/on-boarding/types/OnboardingToast.types';
 
+import { useInviteMembersMutation } from '@features/on-boarding/hooks/mutations/useInviteMemberMutation';
 import {
   useOnboardingActions,
   useOnboardingState,
 } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 import { useOnboardingToastActions } from '@features/on-boarding/hooks/stores/useOnboardingToastStore';
-
-import { useInviteMembersMutation } from '@features/on-boarding/mutations/useInviteMemberMutation';
 
 const OnBoardingInviteStep = () => {
   const { setEmails, nextStep } = useOnboardingActions();

--- a/src/features/on-boarding/components/OnBoardingInviteStep/OnBoardingInviteStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingInviteStep/OnBoardingInviteStep.tsx
@@ -12,14 +12,19 @@ import { OnboardingToastType } from '@features/on-boarding/types/OnboardingToast
 
 import {
   useOnboardingActions,
-  useOnboardingEmails,
+  useOnboardingState,
 } from '@features/on-boarding/hooks/stores/useOnBoardingStore';
 import { useOnboardingToastActions } from '@features/on-boarding/hooks/stores/useOnboardingToastStore';
 
+import { useInviteMembersMutation } from '@features/on-boarding/mutations/useInviteMemberMutation';
+
 const OnBoardingInviteStep = () => {
   const { setEmails, nextStep } = useOnboardingActions();
-  const emails = useOnboardingEmails();
+  const { workspaceId, emails } = useOnboardingState();
   const [value, setValue] = useState('');
+  const [isInvited, setIsInvited] = useState(false); // 초대 완료 여부 state
+
+  const { mutate: inviteMembers, isPending: isInviting } = useInviteMembersMutation();
 
   // 토스트 띄우기 유틸
   const { showOnboardingToast } = useOnboardingToastActions();
@@ -33,30 +38,44 @@ const OnBoardingInviteStep = () => {
     nextStep();
   };
 
-  const handleInvite = (emails: string[]) => {
-    // 초대 버튼 클릭 시 호출 됩니다. -> 이메일 목록 반환
-    // 이메일 목록은 여기서 반환되고 기존 이메일 목록은 제거됩니다.
-    console.log('초대할 이메일 목록:', emails);
-    // 온보딩 토스트 띄우귀
-    showOnboardingToast({
-      type: OnboardingToastType.SUCCESS_INVITE,
-    });
-  };
+  const handleInvite = (emailsToInvite: string[]) => {
+    if (!workspaceId) {
+      console.error('워크스페이스 ID가 없습니다.');
+      return;
+    }
 
-  const isNextButtonDisabled = emails.length === 0;
+    console.log('[OnBoardingInviteStep] 초대 API 요청 값:', {
+      workspaceId,
+      emails: emailsToInvite,
+    });
+
+    inviteMembers(
+      { workspaceId, emails: emailsToInvite },
+      {
+        onSuccess: () => {
+          console.log('워크스페이스 초대 성공');
+          showOnboardingToast({ type: OnboardingToastType.SUCCESS_INVITE });
+          setIsInvited(true);
+        },
+        onError: (error) => {
+          console.error('멤버 초대 실패:', error);
+        },
+      },
+    );
+  };
 
   return (
     <div className="flex flex-col">
       <p className="text-t2-bd mb-6pxr whitespace-pre-line">
         {`워크스페이스에 초대할 팀원의 \n 이메일 주소를 입력해주세요.`}
       </p>
-      <p className="text-b2-rg mb-36pxr text-gray-200">
+      <p className="text-b2-rg mb-44pxr text-gray-200">
         함께할 팀원들의 이메일을 입력해 초대해 보세요.
       </p>
 
-      <div className="mb-228pxr relative">
+      <div className="mb-217pxr relative">
         <InputInviteMember
-          className="absolute"
+          className="w-414pxr absolute"
           title=""
           value={value}
           onValueChange={setValue}
@@ -67,13 +86,18 @@ const OnBoardingInviteStep = () => {
       </div>
 
       <div className="gap-8pxr flex">
-        <SkipForNowButton buttonType={SkipForNowButtonType.SIZE_48} onClick={handleSkip} />
-
-        <MoveToNextButton
-          onClick={handleNext}
-          width={MoveToNextButtonWidth.WIDTH_260}
-          disabled={isNextButtonDisabled}
-        />
+        {isInvited ? (
+          <MoveToNextButton onClick={handleNext} width={MoveToNextButtonWidth.WIDTH_414} />
+        ) : (
+          <>
+            <SkipForNowButton buttonType={SkipForNowButtonType.SIZE_48} onClick={handleSkip} />
+            <MoveToNextButton
+              onClick={handleNext}
+              width={MoveToNextButtonWidth.WIDTH_260}
+              disabled={true}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/features/on-boarding/components/OnBoardingInviteStep/OnBoardingInviteStep.tsx
+++ b/src/features/on-boarding/components/OnBoardingInviteStep/OnBoardingInviteStep.tsx
@@ -39,20 +39,13 @@ const OnBoardingInviteStep = () => {
 
   const handleInvite = (emailsToInvite: string[]) => {
     if (!workspaceId) {
-      console.error('워크스페이스 ID가 없습니다.');
       return;
     }
-
-    console.log('[OnBoardingInviteStep] 초대 API 요청 값:', {
-      workspaceId,
-      emails: emailsToInvite,
-    });
 
     inviteMembers(
       { workspaceId, emails: emailsToInvite },
       {
         onSuccess: () => {
-          console.log('워크스페이스 초대 성공');
           showOnboardingToast({ type: OnboardingToastType.SUCCESS_INVITE });
           setIsInvited(true);
         },
@@ -75,7 +68,6 @@ const OnBoardingInviteStep = () => {
       <div className="mb-217pxr relative">
         <InputInviteMember
           className="w-414pxr absolute"
-          title=""
           value={value}
           onValueChange={setValue}
           onInvite={handleInvite}

--- a/src/features/on-boarding/components/OnBoardingNameStep/OnBoardingNameStep.client.tsx
+++ b/src/features/on-boarding/components/OnBoardingNameStep/OnBoardingNameStep.client.tsx
@@ -11,14 +11,16 @@ const OnBoardingNameStep = () => {
   const { setName, nextStep } = useOnboardingActions();
   const [inputName, setInputName] = useState('');
 
-  // 임시 더미 데이터
+  // 임시 더미 데이터, 추후 전역 user 정보로 대체 예정
   const user = {
     name: '황지원',
   };
 
   const handleNext = () => {
     if (!inputName.trim()) return;
-    setName(inputName.trim());
+    const trimmedName = inputName.trim();
+    console.log('[OnBoardingNameStep] 워크스페이스 이름:', trimmedName);
+    setName(trimmedName);
     nextStep();
   };
 

--- a/src/features/on-boarding/components/OnBoardingNameStep/OnBoardingNameStep.client.tsx
+++ b/src/features/on-boarding/components/OnBoardingNameStep/OnBoardingNameStep.client.tsx
@@ -19,7 +19,6 @@ const OnBoardingNameStep = () => {
   const handleNext = () => {
     if (!inputName.trim()) return;
     const trimmedName = inputName.trim();
-    console.log('[OnBoardingNameStep] 워크스페이스 이름:', trimmedName);
     setName(trimmedName);
     nextStep();
   };

--- a/src/features/on-boarding/constants/end-point.constants.ts
+++ b/src/features/on-boarding/constants/end-point.constants.ts
@@ -1,0 +1,4 @@
+export const API_ENDPOINTS = {
+  WORKSPACES: '/workspaces',
+  INVITE_MEMBERS: '/workspaces/invite',
+} as const;

--- a/src/features/on-boarding/constants/end-point.constants.ts
+++ b/src/features/on-boarding/constants/end-point.constants.ts
@@ -1,4 +1,5 @@
 export const API_ENDPOINTS = {
   WORKSPACES: '/workspaces',
   INVITE_MEMBERS: '/workspaces/invite',
+  WORKSPACE_DETAIL: (workspaceId: number) => `/workspace/${workspaceId}`,
 } as const;

--- a/src/features/on-boarding/hooks/mutations/useCreateWorkspaceMutation.ts
+++ b/src/features/on-boarding/hooks/mutations/useCreateWorkspaceMutation.ts
@@ -2,8 +2,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import queryKeys from '@common/constants/query-key.constants';
 
-import { createWorkspace } from '../apis/post/create-workspace';
-import { CreateWorkspaceRequestDto } from '../types/apis.types';
+import { CreateWorkspaceRequestDto } from '@features/on-boarding/types/apis.types';
+
+import { createWorkspace } from '@features/on-boarding/apis/post/create-workspace';
 
 /**
  * 워크스페이스 생성을 위한 useMutation 커스텀 훅

--- a/src/features/on-boarding/hooks/mutations/useInviteMemberMutation.ts
+++ b/src/features/on-boarding/hooks/mutations/useInviteMemberMutation.ts
@@ -2,8 +2,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import queryKeys from '@common/constants/query-key.constants';
 
-import { inviteMembers } from '../apis/post/invite-member';
-import { InviteMembersRequestDto } from '../types/apis.types';
+import { InviteMembersRequestDto } from '@features/on-boarding/types/apis.types';
+
+import { inviteMembers } from '@features/on-boarding/apis/post/invite-member';
 
 /**
  * 워크스페이스에 멤버를 초대하기 위한 커스텀 Mutation 훅

--- a/src/features/on-boarding/hooks/stores/useOnBoardingStore.ts
+++ b/src/features/on-boarding/hooks/stores/useOnBoardingStore.ts
@@ -10,6 +10,7 @@ export const useOnboardingState = () =>
       step: state.step,
       name: state.name,
       image: state.image,
+      workspaceId: state.workspaceId,
       emails: state.emails,
     })),
   );
@@ -22,6 +23,9 @@ export const useOnboardingStep = () => useOnboardingStore((state) => state.step)
 
 // 이메일만 가져오는 훅
 export const useOnboardingEmails = () => useOnboardingStore((state) => state.emails);
+
+// 워크스페이스 ID만 가져오는 훅
+export const useOnboardingWorkspaceId = () => useOnboardingStore((state) => state.workspaceId);
 
 // 인스타그램 연동 확인 훅
 export const useInstagramConnection = () =>

--- a/src/features/on-boarding/mocks/dummy-files.ts
+++ b/src/features/on-boarding/mocks/dummy-files.ts
@@ -1,0 +1,29 @@
+import { FileType } from '@common/types/file-type.enum';
+
+import { DocumentType } from '@common/components/etc/BoxedFile/BoxedFile.types';
+
+export const ctaItems = [
+  { type: FileType.AI_MEETING_MANAGER, onClick: () => console.log('AI') },
+  { type: FileType.SNS_EVENT_ASSISTANT, onClick: () => console.log('SNS') },
+  { type: FileType.TEAM_MOOD_TRACKER, onClick: () => console.log('TEAM') },
+];
+
+const now = new Date();
+const docTypes: DocumentType[] = [
+  DocumentType.AI_MEETING_MANAGER,
+  DocumentType.SNS_EVENT_ASSISTANT,
+  DocumentType.TEAM_MOOD_TRACKER,
+];
+
+export const dummyFiles = Array.from({ length: 5 }, (_, index) => {
+  const date = new Date(now);
+  date.setHours(date.getHours() - index * 4);
+  const title = `${date.getMonth() + 1}월 ${date.getDate()}일 회의록`;
+
+  return {
+    title,
+    lastOpened: date.toISOString(),
+    documentType: docTypes[index % docTypes.length],
+    thumbnailUrl: '',
+  };
+});

--- a/src/features/on-boarding/mutations/useCreateWorkspaceMutation.ts
+++ b/src/features/on-boarding/mutations/useCreateWorkspaceMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import queryKeys from '@common/constants/query-key.constants';
+
+import { createWorkspace } from '../apis/post/create-workspace';
+import { CreateWorkspaceRequestDto } from '../types/apis.types';
+
+/**
+ * 워크스페이스 생성을 위한 useMutation 커스텀 훅
+ */
+
+export const useCreateWorkspaceMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (workspaceData: CreateWorkspaceRequestDto) => createWorkspace(workspaceData),
+
+    onSuccess: (data) => {
+      console.log('워크스페이스 생성 성공:', data.result);
+      // 성공 시 'workspaces' 쿼리를 무효화하여
+      // 워크스페이스 목록을 다시 불러오도록 할 수 있습니다.
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces._def });
+    },
+
+    onError: (error) => {
+      console.error('워크스페이스 생성 실패:', error);
+    },
+  });
+};

--- a/src/features/on-boarding/mutations/useInviteMemberMutation.ts
+++ b/src/features/on-boarding/mutations/useInviteMemberMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import queryKeys from '@common/constants/query-key.constants';
+
+import { inviteMembers } from '../apis/post/invite-member';
+import { InviteMembersRequestDto } from '../types/apis.types';
+
+/**
+ * 워크스페이스에 멤버를 초대하기 위한 커스텀 Mutation 훅
+ */
+
+export const useInviteMembersMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: InviteMembersRequestDto) => inviteMembers(data),
+
+    onSuccess: (data, variables) => {
+      console.log('멤버 초대 성공:', data);
+
+      queryClient.invalidateQueries({
+        ...queryKeys.workspaces.members(variables.workspaceId),
+      });
+    },
+    onError: (error) => {
+      console.error('멤버 초대 실패:', error);
+    },
+  });
+};

--- a/src/features/on-boarding/stores/on-boarding-store.ts
+++ b/src/features/on-boarding/stores/on-boarding-store.ts
@@ -8,11 +8,13 @@ interface OnboardingStoreState {
   step: OnboardingStep;
   name: string;
   image: File | null;
+  workspaceId: number | null;
   emails: string[];
   isInstagramConnected: boolean;
   actions: {
     setName: (name: string) => void;
     setImage: (file: File) => void;
+    setWorkspaceId: (id: number) => void;
     addEmail: (email: string) => void;
     removeEmail: (index: number) => void;
     setEmails: (emails: string[]) => void;
@@ -29,6 +31,7 @@ const useOnboardingStore = create<OnboardingStoreState>()(
       step: OnboardingStep.NAME,
       name: '',
       image: null,
+      workspaceId: null,
       emails: [],
       isInstagramConnected: false,
 
@@ -40,6 +43,10 @@ const useOnboardingStore = create<OnboardingStoreState>()(
         setImage: (file) =>
           set((state) => {
             state.image = file;
+          }),
+        setWorkspaceId: (id) =>
+          set((state) => {
+            state.workspaceId = id;
           }),
         addEmail: (email) =>
           set((state) => {

--- a/src/features/on-boarding/types/apis.types.ts
+++ b/src/features/on-boarding/types/apis.types.ts
@@ -1,0 +1,16 @@
+// Request DTO
+export interface CreateWorkspaceRequestDto {
+  name: string;
+  image: File | null;
+}
+
+export interface InviteMembersRequestDto {
+  workspaceId: number;
+  emails: string[];
+}
+
+// Response DTO
+export interface CreateWorkspaceResponseDto {
+  workspaceId: number;
+  name: string;
+}

--- a/src/features/on-boarding/types/apis.types.ts
+++ b/src/features/on-boarding/types/apis.types.ts
@@ -13,4 +13,5 @@ export interface InviteMembersRequestDto {
 export interface CreateWorkspaceResponseDto {
   workspaceId: number;
   name: string;
+  imageUrl: string;
 }

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,3 +1,5 @@
+import { joinURL } from '@common/utils/join-url.utils';
+
 import { captureApiError } from './sentry';
 
 interface CreateFetcherOptions {
@@ -55,17 +57,24 @@ const handleResponseError = async (res: Response, url: string, requestBodyRaw: u
 
 export const createFetcher =
   ({
-    baseURL = process.env.SERVER_API_BASE_URL,
+    baseURL = process.env.NEXT_PUBLIC_SERVER_API_BASE_URL,
     headers,
     fetchOptions,
   }: CreateFetcherOptions = {}) =>
   async <T>(path: string, options?: RequestInit): Promise<T> => {
-    const url =
-      typeof window === 'undefined' ? `${baseURL}${path}` : `${window.location.origin}/${path}`;
+    if (!baseURL) {
+      throw new Error('baseURL is not defined. Check your createFetcher arguments or .env file.');
+    }
+    const url = joinURL(baseURL, path);
+
+    // ★ 1. body가 FormData인지 확인합니다.
+    const isFormData = options?.body instanceof FormData;
 
     const mergedHeaders: HeadersInit = {
-      'Content-Type': 'application/json',
+      // ★ 2. FormData가 아닐 때만 Content-Type을 기본으로 설정합니다.
+      ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
       Accept: 'application/json',
+      Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
       ...headers,
       ...options?.headers,
     };

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -63,15 +63,18 @@ export const createFetcher =
   }: CreateFetcherOptions = {}) =>
   async <T>(path: string, options?: RequestInit): Promise<T> => {
     if (!baseURL) {
-      throw new Error('baseURL is not defined. Check your createFetcher arguments or .env file.');
+      throw new Error(
+        'API baseURL이 누락되었습니다. NEXT_PUBLIC_SERVER_API_BASE_URL 환경 변수를 확인하세요.',
+      );
     }
+
     const url = joinURL(baseURL, path);
 
-    // ★ 1. body가 FormData인지 확인합니다.
+    // body가 FormData인지 확인합니다.
     const isFormData = options?.body instanceof FormData;
 
     const mergedHeaders: HeadersInit = {
-      // ★ 2. FormData가 아닐 때만 Content-Type을 기본으로 설정합니다.
+      // FormData가 아닐 때만 Content-Type을 기본으로 설정합니다.
       ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
       Accept: 'application/json',
       Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -38,6 +38,7 @@ const handleResponseError = async (res: Response, url: string, requestBodyRaw: u
   }
 
   const error = new Error(`❌ API error ${res.status}`);
+
   if (res.status >= 500) {
     captureApiError(
       error,
@@ -73,14 +74,39 @@ export const createFetcher =
     // body가 FormData인지 확인합니다.
     const isFormData = options?.body instanceof FormData;
 
-    const mergedHeaders: HeadersInit = {
-      // FormData가 아닐 때만 Content-Type을 기본으로 설정합니다.
-      ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
-      Accept: 'application/json',
-      Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
-      ...headers,
-      ...options?.headers,
-    };
+    // 1. Headers 클래스를 사용해 모든 헤더를 일관되고 안전하게 관리합니다.
+    //    (as any 같은 타입 단언 없이 타입 안정성을 지킬 수 있습니다.)
+    const mergedHeaders = new Headers(headers);
+
+    // 2. API 호출 시점에 전달된 개별 헤더를 병합합니다.
+    //    (이전 헤더를 덮어쓰므로 순서에 상관없이 동작합니다.)
+    if (options?.headers) {
+      new Headers(options.headers).forEach((value, key) => {
+        mergedHeaders.set(key, value);
+      });
+    }
+
+    // 3. 기본 헤더(Accept, Authorization)를 설정합니다.
+    //    (이미 설정된 값이 없다면 기본값을 사용합니다.)
+    if (!mergedHeaders.has('Accept')) {
+      mergedHeaders.set('Accept', 'application/json');
+    }
+    if (!mergedHeaders.has('Authorization') && process.env.NEXT_PUBLIC_ACCESS_TOKEN) {
+      mergedHeaders.set('Authorization', `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`);
+    }
+
+    // 4. FormData 여부에 따라 Content-Type을 최종적으로 제어합니다.
+    if (isFormData) {
+      // FormData일 경우, 다른 곳에서 실수로 Content-Type을 설정했더라도
+      // 여기서 확실하게 제거하여 브라우저가 자동으로 설정하도록 보장합니다.
+      mergedHeaders.delete('Content-Type');
+    } else {
+      // FormData가 아니면서 Content-Type이 설정되지 않은 경우에만
+      // 기본값으로 'application/json'을 설정합니다.
+      if (!mergedHeaders.has('Content-Type')) {
+        mergedHeaders.set('Content-Type', 'application/json');
+      }
+    }
 
     const mergedOptions: RequestInit = {
       ...fetchOptions,

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -8,6 +8,14 @@ interface CreateFetcherOptions {
   fetchOptions?: RequestInit;
 }
 
+interface CustomRequestInit extends RequestInit {
+  /**
+   * 이 요청에 인증 헤더가 필요한지 여부를 결정합니다.
+   * `false`로 설정하면, 환경 변수에 토큰이 있더라도 Authorization 헤더를 보내지 않습니다.
+   */
+  auth?: boolean;
+}
+
 // 정상 응답 처리 함수
 const handleResponse = async (res: Response) => {
   return res.json();
@@ -62,7 +70,7 @@ export const createFetcher =
     headers,
     fetchOptions,
   }: CreateFetcherOptions = {}) =>
-  async <T>(path: string, options?: RequestInit): Promise<T> => {
+  async <T>(path: string, options?: CustomRequestInit): Promise<T> => {
     if (!baseURL) {
       throw new Error(
         'API baseURL이 누락되었습니다. NEXT_PUBLIC_SERVER_API_BASE_URL 환경 변수를 확인하세요.',
@@ -91,7 +99,15 @@ export const createFetcher =
     if (!mergedHeaders.has('Accept')) {
       mergedHeaders.set('Accept', 'application/json');
     }
-    if (!mergedHeaders.has('Authorization') && process.env.NEXT_PUBLIC_ACCESS_TOKEN) {
+
+    const requiresAuth = options?.auth !== false;
+
+    // 인증이 필요하고, 수동으로 설정된 Authorization 헤더가 없으며, 토큰이 존재할 때만 헤더를 추가합니다.
+    if (
+      requiresAuth &&
+      !mergedHeaders.has('Authorization') &&
+      process.env.NEXT_PUBLIC_ACCESS_TOKEN
+    ) {
       mergedHeaders.set('Authorization', `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`);
     }
 


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.

- Issue #187 #191 #192 

## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

- create workspace api 연동 - ~~백엔드 측 미완성 api~~ ( 7/31 연동 완료 )
- invite member api 연동 - ~~workspaceId 를 받지 못 함 ( create wokrspace api 미완성 )~~  ( 7/31 연동 완료 )
  - ~~둘 다 전체적인 테만 잡아두었습니다.~~  ( 7/31 연동 완료 )
  - ~~백엔드 측 완성 되면 다시 시도하도록 하겠습니다. ( 현재 415 에러 발생 )~~  ( 7/31 연동 완료 )
 

- 똑같은 응답 BaseResponseDto 로 선언해두었습니다.
  - api 마다 request 와 responseDto type으로 빼두었습니다.

- queryKey 관련하여 query-key-factory 를 사용하였습니다.
  - queryKey 관리 방법 중 하나라고 합니다. ( 이전 매튜 추천으로 사용 해봤습니다. )
  
- fetcher.ts application/json으로 하드 코딩되어 있어 formData 인 상황은 제외하고 application/json 으로 동작되게 변동시켰습니다.
  - url api 요청시에 localhost:3000 으로 보내는 문제로 인해
    -  서버에서 실행되든 클라이언트에서 실행되든 항상 baseURL을 기준으로 전체 API 주소를 일관되게 변동시켰습니다.
  - login 구현전 auth 접근을 위해 access_token 란을 Header 에 추가해두었습니다.

- FormData일 때 Content-Type을 제거하면 브라우저가 자동으로
  - Content-Type: multipart/form-data; boundary=----WebKitFormBoundary...로 설정해서 모든 파일 타입과 multiple 파일을 처리한다고 합니다.
 
## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.

https://github.com/user-attachments/assets/96f62446-1616-4d9b-8004-b517fb12a90f



## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

-

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
