### PR TITLE
[Refactor] Query Client 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,4 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/nextjs,windows,linux,macos,git,dotenv,visualstudiocode,webstorm
 *storybook.log
 storybook-static
+certificates

--- a/src/app/query-client-providers.tsx
+++ b/src/app/query-client-providers.tsx
@@ -1,28 +1,16 @@
 'use client';
 
-import { useState } from 'react';
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+import { getQueryClient } from '@common/utils/get-query-client';
 
 interface QueryClientProvidersProps {
   children: React.ReactNode;
-  dehydratedState?: unknown; // 서버에서 받은 상태
 }
 
-const QueryClientProviders = ({ children, dehydratedState }: QueryClientProvidersProps) => {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 60 * 1000, // 1분
-            gcTime: 5 * 60 * 1000, // 5분
-            retry: false,
-          },
-        },
-      }),
-  );
+const QueryClientProviders = ({ children }: QueryClientProvidersProps) => {
+  const queryClient = getQueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/common/utils/dehydrate.ts
+++ b/src/common/utils/dehydrate.ts
@@ -16,23 +16,22 @@
  */
 import { DehydratedState, QueryClient, dehydrate } from '@tanstack/react-query';
 
+import { getQueryClient } from './get-query-client';
+
 interface DehydrationOptions {
-  // 쿼리 클라이언트 설정 다르게 하려면
-  queryClient?: QueryClient;
   // 원하는 prefetch 함수: 내부에서 여러 쿼리 실행 가능
   prefetch: (queryClient: QueryClient) => Promise<void>;
 }
 
 // 서버에서 데이터를 미리 fetch해, 직렬화된 React Query 상태 반환
 export const getDehydratedState = async ({
-  queryClient = new QueryClient(),
   prefetch,
 }: DehydrationOptions): Promise<{
   dehydratedState: DehydratedState;
-  queryClient: QueryClient;
 }> => {
+  const queryClient = getQueryClient();
   await prefetch(queryClient);
   const dehydratedState = dehydrate(queryClient); // React Query 캐시 직렬화
 
-  return { dehydratedState, queryClient };
+  return { dehydratedState };
 };

--- a/src/common/utils/get-query-client.ts
+++ b/src/common/utils/get-query-client.ts
@@ -1,0 +1,45 @@
+/**
+ * 서버, 클라이언트에 따라
+ * QueryClient를 생성/관리하는 유틸
+ */
+import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/react-query';
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // 1분
+        gcTime: 5 * 60 * 1000, // 5분
+        retry: false,
+      },
+      dehydrate: {
+        // 쿼리를 직렬화할 때 포함할지 여부 결정하는 로직 - 요청 중인 쿼리도 포함
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) || query.state.status === 'pending',
+        // Next.js 서버 에러는 건들지 않음 - Next가 자체적으로 가공함
+        shouldRedactErrors: (error) => {
+          return false;
+        },
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export function getQueryClient() {
+  if (isServer) {
+    // 서버 환경:
+    // 매 요청마다 새로운 QueryClient 생성
+    // 이유: 요청 간에 캐시가 공유되면 다른 사용자의 데이터가 섞이는 문제가 생김
+    return makeQueryClient();
+  } else {
+    // 브라우저 환경:
+    // 최초 렌더링 시에만 새 QueryClient 생성
+    // 이후에는 기존 QueryClient를 재사용
+    // 이유: 리렌더링 또는 React Suspense 발생 시마다
+    // 새로 생성하면 캐시가 날아가므로 전역 유지 필요
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.

- Issue #214 

## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

- QueryClient 생성 로직 분리

getQueryClient 유틸을 도입하여
서버/클라이언트 환경에 따라 QueryClient 생성 방식 분리

💡 서버에서 요청마다 QueryClient 만들어 요청 -> HydrationBoundary로 클라이언트에 전달 -> 클라이언트의 단일 QueryClient 캐시에 저장됨

`서버`: 요청(Request) 단위로 항상 새 QueryClient 생성 → 서버는 동시에 여러 사용자의 요청을 처리하므로 사용자 간 데이터 꼬임 방지

`클라이언트`: 최초 한 번만 생성 후 전역 공유 → 캐시 유지 및 재요청 방지

## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

## 📝 Checklist

- [ ] Reviewer를 추가했나요?
- [ ] Convention을 준수했나요?