### PR TITLE
[Fix] SNS 이벤트 어시스턴트 수정

### DIFF
--- a/src/api/sns-event-assistant/api.types.ts
+++ b/src/api/sns-event-assistant/api.types.ts
@@ -1,7 +1,10 @@
 /**
  * 다운로드 포맷 타입을 정의합니다.
  */
-import { Format, SnsEventAssistantListType } from '@common/types/download.enum.types';
+import { ApiErrorBody } from '@common/types/api.common.types';
+import { DownloadFormat, SnsEventAssistantListType } from '@common/types/download.enum.types';
+
+import { ApiError } from '@common/errors/ApiError';
 
 /**
  * SNS 이벤트 ID를 포함하는 기본 인터페이스.
@@ -116,7 +119,7 @@ export type GetSnsEventAssistantListRequestDto = WorkspaceId;
  */
 export interface GetSnsEventAssistantListDownloadRequestDto extends SnsEventAssistantId {
   listType: SnsEventAssistantListType;
-  format: Format;
+  format: DownloadFormat;
 }
 
 /**
@@ -157,4 +160,10 @@ export interface GetSnsEventAssistantListResponseDto {
  */
 export interface GetSnsEventAssistantListDownloadResponseDto {
   downloadLink: string;
+}
+
+export interface UseSnsEventAssistantListDownloadOptions {
+  enabled?: boolean;
+  onSuccess?: (data: GetSnsEventAssistantListDownloadResponseDto) => void;
+  onError?: (error: ApiError<ApiErrorBody>) => void;
 }

--- a/src/api/sns-event-assistant/api.types.ts
+++ b/src/api/sns-event-assistant/api.types.ts
@@ -1,15 +1,34 @@
-// CRUD 순서
+/**
+ * 다운로드 포맷 타입을 정의합니다.
+ */
 import { Format, SnsEventAssistantListType } from '@common/types/download.enum.types';
 
-// 객체
+/**
+ * SNS 이벤트 ID를 포함하는 기본 인터페이스.
+ * @property {string} snsEventId - SNS 이벤트의 고유 식별자.
+ */
 export interface SnsEventAssistantId {
   snsEventId: string;
 }
 
+/**
+ * 워크스페이스 ID를 포함하는 기본 인터페이스.
+ * @property {string} workspaceId - 워크스페이스의 고유 식별자.
+ */
 export interface WorkspaceId {
   workspaceId: string;
 }
 
+/**
+ * SNS 이벤트 추첨 조건을 정의하는 인터페이스.
+ * @property {number} winnerCount - 당첨자 수.
+ * @property {boolean} isPeriod - 기간 필터 적용 여부.
+ * @property {Date | null} period - 추첨 기간. `isPeriod`가 `true`일 경우 유효.
+ * @property {boolean} isKeyword - 키워드 필터 적용 여부.
+ * @property {string | null} keyword - 포함할 키워드. `isKeyword`가 `true`일 경우 유효.
+ * @property {boolean} isTaged - 태그 필터 적용 여부.
+ * @property {number | null} tageCount - 태그된 계정 수. `isTaged`가 `true`일 경우 유효.
+ */
 export interface SnsEventAssistantCondition {
   winnerCount: number;
   isPeriod: boolean;
@@ -20,10 +39,23 @@ export interface SnsEventAssistantCondition {
   tageCount: number | null;
 }
 
+/**
+ * 참여자/당첨자 목록에 사용되는 사용자 계정 인터페이스.
+ * @property {string} account - 사용자 계정.
+ */
 export interface PeopleList {
   account: string;
 }
 
+/**
+ * SNS 이벤트 목록 조회에 사용되는 객체 인터페이스.
+ * `SnsEventAssistantId`를 상속받습니다.
+ * @property {string} title - 이벤트 제목.
+ * @property {number} participantCount - 이벤트 참여자 수.
+ * @property {number} winnerCount - 이벤트 당첨자 수.
+ * @property {string} snsLink - SNS 이벤트 원본 링크.
+ * @property {Date} updatedAt - 최종 업데이트 날짜.
+ */
 export interface SnsEventAssistantListObject extends SnsEventAssistantId {
   title: string;
   participantCount: number;
@@ -32,6 +64,17 @@ export interface SnsEventAssistantListObject extends SnsEventAssistantId {
   updatedAt: Date;
 }
 
+/**
+ * SNS 이벤트 상세 조회에 사용되는 객체 인터페이스.
+ * `WorkspaceId`를 상속받습니다.
+ * @property {string} title - 이벤트 제목.
+ * @property {string} creatorId - 생성자 ID.
+ * @property {string} creatorName - 생성자 이름.
+ * @property {Date} updatedAt - 최종 업데이트 날짜.
+ * @property {PeopleList[]} participantList - 참여자 목록.
+ * @property {PeopleList[]} winnerList - 당첨자 목록.
+ * @property {string} snsLink - SNS 이벤트 원본 링크.
+ */
 export interface SnsEventAssistantObject extends WorkspaceId {
   title: string;
   creatorId: string;
@@ -42,9 +85,12 @@ export interface SnsEventAssistantObject extends WorkspaceId {
   snsLink: string;
 }
 
-// Request DTO
 /**
- * SNS 이벤트 어시스턴트 생성 Request DTO
+ * SNS 이벤트 생성 요청 데이터 전송 객체 (DTO).
+ * `WorkspaceId`를 상속받습니다.
+ * @property {string} title - 이벤트 제목.
+ * @property {string} snsEventLink - SNS 이벤트 원본 링크.
+ * @property {SnsEventAssistantCondition} snsCondition - 이벤트 추첨 조건.
  */
 export interface CreateSnsEventAssistantRequestDto extends WorkspaceId {
   title: string;
@@ -53,17 +99,20 @@ export interface CreateSnsEventAssistantRequestDto extends WorkspaceId {
 }
 
 /**
- * SNS 이벤트 어시스턴트 조회 Request DTO
+ * SNS 이벤트 조회 요청 데이터 전송 객체 (DTO).
  */
 export type GetSnsEventAssistantRequestDto = SnsEventAssistantId;
 
 /**
- * SNS 이벤트 어시스턴트 리스트 조회 Request DTO
+ * SNS 이벤트 리스트 조회 요청 데이터 전송 객체 (DTO).
  */
 export type GetSnsEventAssistantListRequestDto = WorkspaceId;
 
 /**
- * SNS 이벤트 어시스턴트 리스트 다운로드 Request DTO
+ * SNS 이벤트 리스트 다운로드 요청 데이터 전송 객체 (DTO).
+ * `SnsEventAssistantId`를 상속받습니다.
+ * @property {SnsEventAssistantListType} listType - 다운로드할 목록의 타입 (예: `PARTICIPANT`, `WINNER`).
+ * @property {Format} format - 다운로드 파일 포맷 (예: `CSV`, `XLSX`).
  */
 export interface GetSnsEventAssistantListDownloadRequestDto extends SnsEventAssistantId {
   listType: SnsEventAssistantListType;
@@ -71,40 +120,41 @@ export interface GetSnsEventAssistantListDownloadRequestDto extends SnsEventAssi
 }
 
 /**
- * SNS 이벤트 어시스턴트 수정 Request DTO
+ * SNS 이벤트 수정 요청 데이터 전송 객체 (DTO).
+ * `SnsEventAssistantId`를 상속받습니다.
+ * @property {string} title - 수정할 이벤트 제목.
  */
 export interface UpdateSnsEventAssistantRequestDto extends SnsEventAssistantId {
   title: string;
 }
 
 /**
- * SNS 이벤트 어시스턴트 삭제 Request DTO
+ * SNS 이벤트 삭제 요청 데이터 전송 객체 (DTO).
  */
 export type DeleteSnsEventAssistantRequestDto = SnsEventAssistantId;
 
-// Response DTO
 /**
- * SNS 이벤트 어시스턴트 생성 Response DTO
+ * SNS 이벤트 생성 응답 데이터 전송 객체 (DTO).
  */
 export type CreateSnsEventAssistantResponseDto = SnsEventAssistantId;
 
 /**
- * SNS 이벤트 어시스턴트 조회 Response DTO
+ * SNS 이벤트 조회 응답 데이터 전송 객체 (DTO).
  */
 export type GetSnsEventAssistantResponseDto = SnsEventAssistantObject;
 
 /**
- * SNS 이벤트 어시스턴트 리스트 조회 Response DTO
+ * SNS 이벤트 리스트 조회 응답 데이터 전송 객체 (DTO).
+ * @property {SnsEventAssistantListObject[]} snsEventList - 조회된 SNS 이벤트 목록.
  */
 export interface GetSnsEventAssistantListResponseDto {
   snsEventList: SnsEventAssistantListObject[];
 }
 
 /**
- * SNS 이벤트 어시스턴트 리스트 다운로드 Response DTO
+ * SNS 이벤트 리스트 다운로드 응답 데이터 전송 객체 (DTO).
+ * @property {string} downloadLink - 다운로드 가능한 파일의 URL.
  */
 export interface GetSnsEventAssistantListDownloadResponseDto {
   downloadLink: string;
 }
-
-// SNS 이벤트 어시스턴트 update, delete response 없음

--- a/src/api/sns-event-assistant/api.types.ts
+++ b/src/api/sns-event-assistant/api.types.ts
@@ -162,6 +162,9 @@ export interface GetSnsEventAssistantListDownloadResponseDto {
   downloadLink: string;
 }
 
+/**
+ * SNS 이벤트 리스트 다운로드 외부에서 사용할 옵션 인터페이스.
+ */
 export interface UseSnsEventAssistantListDownloadOptions {
   enabled?: boolean;
   onSuccess?: (data: GetSnsEventAssistantListDownloadResponseDto) => void;

--- a/src/api/sns-event-assistant/delete/apis/delete-sns-event.ts
+++ b/src/api/sns-event-assistant/delete/apis/delete-sns-event.ts
@@ -5,6 +5,11 @@ import { BaseResponseDto } from '@common/types/api.common.types';
 import { WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS } from '../../api-end-point.constants';
 import { DeleteSnsEventAssistantRequestDto } from '../../api.types';
 
+/**
+ * SNS 이벤트를 삭제하는 비동기 함수입니다.
+ * @param {DeleteSnsEventAssistantRequestDto} dto - 삭제할 이벤트의 ID를 포함하는 객체입니다.
+ * @param {string} dto.snsEventId - 삭제할 SNS 이벤트의 고유 ID입니다.
+ */
 export const DeleteSnsEvent = async ({ snsEventId }: DeleteSnsEventAssistantRequestDto) => {
   const response = await defaultApi<BaseResponseDto<unknown>>(
     WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_DELETE(snsEventId),

--- a/src/api/sns-event-assistant/delete/mutations/useDeleteSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/delete/mutations/useDeleteSnsEventMutation.ts
@@ -13,6 +13,10 @@ import { ApiError } from '@common/errors/ApiError';
 
 import { DeleteSnsEvent } from '../apis/delete-sns-event';
 
+/**
+ * SNS 이벤트를 삭제하는 TanStack Query 뮤테이션 훅입니다.
+ * @param {string} workspaceId - 삭제 후 SNS 이벤트 목록을 갱신하기 위한 워크스페이스 ID입니다.
+ */
 const useDeleteSnsEventMutation = (workspaceId: string) => {
   const queryClient = useQueryClient();
   return useMutation<

--- a/src/api/sns-event-assistant/delete/mutations/useDeleteSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/delete/mutations/useDeleteSnsEventMutation.ts
@@ -1,24 +1,31 @@
 import { notFound } from 'next/navigation';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { DeleteSnsEventAssistantRequestDto } from '@api/sns-event-assistant/api.types';
 
 import { ApiErrorBody } from '@common/types/api.common.types';
 
 import { API_ERROR_CODES } from '@common/constants/api-error-codes.constants';
+import queryKeys from '@common/constants/query-key.constants';
 
 import { ApiError } from '@common/errors/ApiError';
 
 import { DeleteSnsEvent } from '../apis/delete-sns-event';
 
-const useDeleteSnsEventMutation = () => {
+const useDeleteSnsEventMutation = (workspaceId: string) => {
+  const queryClient = useQueryClient();
   return useMutation<
     unknown, // TData
     ApiError<ApiErrorBody>, // TError
     DeleteSnsEventAssistantRequestDto // TMutateVariables
   >({
     mutationFn: ({ snsEventId }) => DeleteSnsEvent({ snsEventId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.snsEventAssistant.list(workspaceId).queryKey,
+      });
+    },
     onError: (error) => {
       if (error.code === API_ERROR_CODES.SNS_EVENT.NOT_FOUND) {
         notFound();

--- a/src/api/sns-event-assistant/get/apis/get-sns-event-list-download.ts
+++ b/src/api/sns-event-assistant/get/apis/get-sns-event-list-download.ts
@@ -9,6 +9,13 @@ import {
   GetSnsEventAssistantListDownloadResponseDto,
 } from '../../api.types';
 
+/**
+ * SNS 이벤트 목록을 다운로드하는 비동기 함수입니다.
+ * @param {GetSnsEventAssistantListDownloadRequestDto} dto - 다운로드할 목록의 정보와 형식을 포함하는 객체입니다.
+ * @param {string} dto.snsEventId - 다운로드할 SNS 이벤트의 고유 ID입니다.
+ * @param {SnsEventAssistantListType} [dto.listType] - 다운로드할 목록의 타입입니다 (`PARTICIPANT` 또는 `WINNER`). 값이 없을 경우 `PARTICIPANT`로 기본 설정됩니다.
+ * @param {DownloadFormat} [dto.format] - 다운로드할 파일의 형식입니다. 값이 없을 경우 `PDF`로 기본 설정됩니다.
+ */
 export const GetSnsEventListDownLoad = async ({
   snsEventId,
   listType,
@@ -27,8 +34,7 @@ export const GetSnsEventListDownLoad = async ({
     query.append('format', format);
   }
 
-  const url = `${WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_LIST_DOWNLOAD(snsEventId)}?
-    ${query.toString()}`;
+  const url = `${WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_LIST_DOWNLOAD(snsEventId)}?${query.toString()}`;
   const response = await defaultApi<BaseResponseDto<GetSnsEventAssistantListDownloadResponseDto>>(
     url,
     {

--- a/src/api/sns-event-assistant/get/apis/get-sns-event-list.ts
+++ b/src/api/sns-event-assistant/get/apis/get-sns-event-list.ts
@@ -8,6 +8,11 @@ import {
   GetSnsEventAssistantListResponseDto,
 } from '../../api.types';
 
+/**
+ * 특정 워크스페이스의 SNS 이벤트 목록을 조회하는 비동기 함수입니다.
+ * @param {GetSnsEventAssistantListRequestDto} dto - 이벤트 목록을 조회할 워크스페이스 ID를 포함하는 객체입니다.
+ * @param {string} dto.workspaceId - 이벤트 목록을 조회할 워크스페이스의 고유 ID입니다.
+ */
 export const GetSnsEventList = async ({ workspaceId }: GetSnsEventAssistantListRequestDto) => {
   const response = await defaultApi<BaseResponseDto<GetSnsEventAssistantListResponseDto>>(
     WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_LIST_DETAIL(workspaceId),

--- a/src/api/sns-event-assistant/get/apis/get-sns-event.ts
+++ b/src/api/sns-event-assistant/get/apis/get-sns-event.ts
@@ -6,6 +6,11 @@ import { WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS } from '../../api-end-poi
 import '../../api.types';
 import { GetSnsEventAssistantRequestDto, GetSnsEventAssistantResponseDto } from '../../api.types';
 
+/**
+ * 특정 SNS 이벤트의 상세 정보를 조회하는 비동기 함수입니다.
+ * @param {GetSnsEventAssistantRequestDto} dto - 상세 정보를 조회할 SNS 이벤트의 ID를 포함하는 객체입니다.
+ * @param {string} dto.snsEventId - 상세 정보를 조회할 SNS 이벤트의 고유 ID입니다.
+ */
 export const GetSnsEvent = async ({ snsEventId }: GetSnsEventAssistantRequestDto) => {
   const response = await defaultApi<BaseResponseDto<GetSnsEventAssistantResponseDto>>(
     WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_DETAIL(snsEventId),

--- a/src/api/sns-event-assistant/get/queries/useSnsEvent.ts
+++ b/src/api/sns-event-assistant/get/queries/useSnsEvent.ts
@@ -16,7 +16,8 @@ import { useAfterQuery } from '@common/hooks/queries/useAfterQuery';
 import { GetSnsEvent } from '../apis/get-sns-event';
 
 /**
- * SNS 이벤트 상세 조회를 위한 커스텀 훅
+ * 특정 SNS 이벤트의 상세 정보를 조회하는 커스텀 훅입니다.
+ * @param {string} snsEventId - 상세 정보를 조회할 SNS 이벤트의 고유 ID입니다.
  */
 const useSnsEvent = (snsEventId: string) => {
   const handleError = useCallback((error: ApiError<ApiErrorBody>) => {

--- a/src/api/sns-event-assistant/get/queries/useSnsEventList.ts
+++ b/src/api/sns-event-assistant/get/queries/useSnsEventList.ts
@@ -16,8 +16,8 @@ import { useAfterQuery } from '@common/hooks/queries/useAfterQuery';
 import { GetSnsEventList } from '../apis/get-sns-event-list';
 
 /**
- * SNS 이벤트 상세 조회를 위한 커스텀 훅
- * @param {string} workspaceId - 워크스페이스 ID
+ * 특정 워크스페이스의 SNS 이벤트 목록을 조회하는 커스텀 훅입니다.
+ * @param {string} workspaceId - 이벤트 목록을 조회할 워크스페이스의 고유 ID입니다.
  */
 const useSnsEventList = (workspaceId: string) => {
   const handleError = useCallback((error: ApiError<ApiErrorBody>) => {

--- a/src/api/sns-event-assistant/get/queries/useSnsEventList.ts
+++ b/src/api/sns-event-assistant/get/queries/useSnsEventList.ts
@@ -17,6 +17,7 @@ import { GetSnsEventList } from '../apis/get-sns-event-list';
 
 /**
  * SNS 이벤트 상세 조회를 위한 커스텀 훅
+ * @param {string} workspaceId - 워크스페이스 ID
  */
 const useSnsEventList = (workspaceId: string) => {
   const handleError = useCallback((error: ApiError<ApiErrorBody>) => {

--- a/src/api/sns-event-assistant/get/queries/useSnsEventListDownload.ts
+++ b/src/api/sns-event-assistant/get/queries/useSnsEventListDownload.ts
@@ -15,7 +15,12 @@ import { useAfterQuery } from '@common/hooks/queries/useAfterQuery';
 import { GetSnsEventListDownLoad } from '../apis/get-sns-event-list-download';
 
 /**
- * SNS 이벤트 상세 조회를 위한 커스텀 훅
+ * SNS 이벤트 목록을 다운로드하기 위한 TanStack Query 커스텀 훅입니다.
+ * @param {GetSnsEventAssistantListDownloadRequestDto} params - 다운로드에 필요한 이벤트 정보입니다.
+ * @param {string} params.snsEventId - 다운로드할 SNS 이벤트의 고유 ID입니다.
+ * @param {SnsEventAssistantListType} params.listType - 다운로드할 목록의 타입입니다.
+ * @param {DownloadFormat} params.format - 다운로드할 파일의 형식입니다.
+ * @param {UseSnsEventAssistantListDownloadOptions} [options] - useAfterQuery 훅에 전달할 옵션 객체입니다.
  */
 const useSnsEventListDownload = (
   params: GetSnsEventAssistantListDownloadRequestDto,

--- a/src/api/sns-event-assistant/get/queries/useSnsEventListDownload.ts
+++ b/src/api/sns-event-assistant/get/queries/useSnsEventListDownload.ts
@@ -1,13 +1,11 @@
-import { useCallback } from 'react';
-
-import { notFound } from 'next/navigation';
-
-import { GetSnsEventAssistantListDownloadResponseDto } from '@api/sns-event-assistant/api.types';
+import {
+  GetSnsEventAssistantListDownloadRequestDto,
+  GetSnsEventAssistantListDownloadResponseDto,
+  UseSnsEventAssistantListDownloadOptions,
+} from '@api/sns-event-assistant/api.types';
 
 import { ApiErrorBody } from '@common/types/api.common.types';
-import { Format, SnsEventAssistantListType } from '@common/types/download.enum.types';
 
-import { API_ERROR_CODES } from '@common/constants/api-error-codes.constants';
 import queryKeys from '@common/constants/query-key.constants';
 
 import { ApiError } from '@common/errors/ApiError';
@@ -20,33 +18,24 @@ import { GetSnsEventListDownLoad } from '../apis/get-sns-event-list-download';
  * SNS 이벤트 상세 조회를 위한 커스텀 훅
  */
 const useSnsEventListDownload = (
-  snsEventId: string,
-  listType: SnsEventAssistantListType,
-  format: Format,
+  params: GetSnsEventAssistantListDownloadRequestDto,
+  options?: UseSnsEventAssistantListDownloadOptions,
 ) => {
-  const handleError = useCallback((error: ApiError<ApiErrorBody>) => {
-    if (error.code === API_ERROR_CODES.SNS_EVENT.NOT_FOUND) {
-      notFound(); // Next.js not-found.tsx로 이동
-    }
-  }, []);
-
+  const { snsEventId } = params;
+  const { enabled = false, ...restOptions } = options || {};
   // Hydrate된 데이터가 있어 추가 네트워크 요청 없이 바로 캐시 데이터 사용
   return useAfterQuery<
-    { result: GetSnsEventAssistantListDownloadResponseDto }, // TData
-    ApiError<ApiErrorBody>, // TError
-    GetSnsEventAssistantListDownloadResponseDto // TExtra
+    GetSnsEventAssistantListDownloadResponseDto, // TData
+    ApiError<ApiErrorBody> // TError
   >({
     queryKey: queryKeys.snsEventAssistant.download(snsEventId).queryKey,
-    queryFn: () => {
-      return GetSnsEventListDownLoad({ snsEventId, listType, format });
+    queryFn: async () => {
+      const response = await GetSnsEventListDownLoad(params);
+      return response.result;
     },
-    enabled: !!snsEventId,
+    enabled: !!snsEventId && enabled,
     retry: false,
-    onError: handleError,
-    extra: (queryResult) =>
-      queryResult.data?.result ?? {
-        downloadLink: '',
-      },
+    ...restOptions,
   });
 };
 

--- a/src/api/sns-event-assistant/patch/apis/update-sns-event.ts
+++ b/src/api/sns-event-assistant/patch/apis/update-sns-event.ts
@@ -5,6 +5,12 @@ import { BaseResponseDto } from '@common/types/api.common.types';
 import { WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS } from '../../api-end-point.constants';
 import { UpdateSnsEventAssistantRequestDto } from '../../api.types';
 
+/**
+ * 특정 SNS 이벤트의 제목을 수정하는 비동기 함수입니다.
+ * @param {UpdateSnsEventAssistantRequestDto} dto - 수정할 이벤트의 ID와 새로운 제목을 포함하는 객체입니다.
+ * @param {string} dto.snsEventId - 수정할 SNS 이벤트의 고유 ID입니다.
+ * @param {string} dto.title - 수정할 새로운 이벤트 제목입니다.
+ */
 export const UpdateSnsEvent = async ({ snsEventId, title }: UpdateSnsEventAssistantRequestDto) => {
   const response = await defaultApi<BaseResponseDto<unknown>>(
     WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_EDIT(snsEventId),

--- a/src/api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation.ts
@@ -1,24 +1,32 @@
-import { notFound } from 'next/navigation';
+import { notFound, useParams } from 'next/navigation';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { UpdateSnsEventAssistantRequestDto } from '@api/sns-event-assistant/api.types';
 
 import { ApiErrorBody } from '@common/types/api.common.types';
 
 import { API_ERROR_CODES } from '@common/constants/api-error-codes.constants';
+import queryKeys from '@common/constants/query-key.constants';
 
 import { ApiError } from '@common/errors/ApiError';
 
 import { UpdateSnsEvent } from '../apis/update-sns-event';
 
 const useUpdateSnsEventMutation = () => {
+  const queryClient = useQueryClient();
+  const { snsEventId } = useParams<{ snsEventId: string }>();
   return useMutation<
     unknown, // TData
     ApiError<ApiErrorBody>, // TError
     UpdateSnsEventAssistantRequestDto // TMutateVariables
   >({
     mutationFn: ({ snsEventId, title }) => UpdateSnsEvent({ snsEventId, title }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.snsEventAssistant.detail(snsEventId).queryKey,
+      });
+    },
     onError: (error) => {
       if (error.code === API_ERROR_CODES.SNS_EVENT.NOT_FOUND) {
         notFound();

--- a/src/api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation.ts
@@ -13,6 +13,12 @@ import { ApiError } from '@common/errors/ApiError';
 
 import { UpdateSnsEvent } from '../apis/update-sns-event';
 
+/**
+ * SNS 이벤트의 제목을 수정하기 위한 TanStack Query 뮤테이션 훅입니다.
+ * 훅의 `mutate` 함수는 UpdateSnsEventAssistantRequestDto 타입의 객체를 전달받습니다.
+ * @param {string} mutationVariables.snsEventId - 수정할 SNS 이벤트의 고유 ID입니다.
+ * @param {string} mutationVariables.title - 수정할 새로운 이벤트 제목입니다.
+ */
 const useUpdateSnsEventMutation = () => {
   const queryClient = useQueryClient();
   const { snsEventId } = useParams<{ snsEventId: string }>();

--- a/src/api/sns-event-assistant/post/apis/create-sns-event-list-download.ts
+++ b/src/api/sns-event-assistant/post/apis/create-sns-event-list-download.ts
@@ -1,7 +1,9 @@
 import { defaultApi } from '@lib/fetcher';
 
+import { DownloadFormat } from '@api/team-mood-tracker/apis.types';
+
 import { BaseResponseDto } from '@common/types/api.common.types';
-import { DownloadFormat, SnsEventAssistantListType } from '@common/types/download.enum.types';
+import { SnsEventAssistantListType } from '@common/types/download.enum.types';
 
 import { WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS } from '../../api-end-point.constants';
 import {
@@ -9,10 +11,15 @@ import {
   GetSnsEventAssistantListDownloadResponseDto,
 } from '../../api.types';
 
-export const GetSnsEventListDownLoad = async ({
+/**
+ * 일단 임시로 만든 함수 - get인지 post인지에 따라 변경 예정
+ * @param param0
+ * @returns
+ */
+export const CreateSnsEventDownload = async ({
   snsEventId,
-  listType,
   format,
+  listType,
 }: GetSnsEventAssistantListDownloadRequestDto) => {
   const query = new URLSearchParams();
   if (!listType) {
@@ -27,12 +34,11 @@ export const GetSnsEventListDownLoad = async ({
     query.append('format', format);
   }
 
-  const url = `${WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_LIST_DOWNLOAD(snsEventId)}?
-    ${query.toString()}`;
+  const url = `${WORKSPACES_SNS_EVENT_ASSISTANT_API_END_POINTS.SNS_EVENT_ASSISTANT_LIST_DOWNLOAD(snsEventId)}?${query.toString()}`;
   const response = await defaultApi<BaseResponseDto<GetSnsEventAssistantListDownloadResponseDto>>(
     url,
     {
-      method: 'GET',
+      method: 'POST',
       auth: true,
     },
   );

--- a/src/api/sns-event-assistant/post/apis/create-sns-event-list-download.ts
+++ b/src/api/sns-event-assistant/post/apis/create-sns-event-list-download.ts
@@ -12,9 +12,12 @@ import {
 } from '../../api.types';
 
 /**
- * 일단 임시로 만든 함수 - get인지 post인지에 따라 변경 예정
- * @param param0
- * @returns
+ * SNS 이벤트 목록 다운로드 요청을 생성하는 비동기 함수입니다.
+ * API의 요청 방식(GET/POST)에 따라 변경될 수 있습니다.
+ * @param {GetSnsEventAssistantListDownloadRequestDto} dto - 다운로드할 목록의 정보와 형식을 포함하는 객체입니다.
+ * @param {string} dto.snsEventId - 다운로드할 SNS 이벤트의 고유 ID입니다.
+ * @param {DownloadFormat} [dto.format] - 다운로드할 파일의 형식입니다. 값이 없을 경우 `PDF`로 기본 설정됩니다.
+ * @param {SnsEventAssistantListType} [dto.listType] - 다운로드할 목록의 타입입니다. 값이 없을 경우 `PARTICIPANT`로 기본 설정됩니다.
  */
 export const CreateSnsEventDownload = async ({
   snsEventId,

--- a/src/api/sns-event-assistant/post/apis/create-sns-event.ts
+++ b/src/api/sns-event-assistant/post/apis/create-sns-event.ts
@@ -8,6 +8,14 @@ import {
   CreateSnsEventAssistantResponseDto,
 } from '../../api.types';
 
+/**
+ * 새로운 SNS 이벤트를 생성하는 비동기 함수입니다.
+ * @param {CreateSnsEventAssistantRequestDto} dto - 생성할 SNS 이벤트의 정보를 담은 객체입니다.
+ * @param {string} dto.workspaceId - 이벤트를 생성할 워크스페이스의 고유 ID입니다.
+ * @param {string} dto.title - 새로운 이벤트의 제목입니다.
+ * @param {string} dto.snsEventLink - SNS 이벤트의 원본 링크입니다.
+ * @param {SnsEventAssistantCondition} dto.snsCondition - 이벤트 추첨 조건을 정의하는 객체입니다.
+ */
 export const CreateSnsEvent = async ({
   workspaceId,
   title,

--- a/src/api/sns-event-assistant/post/mutations/useCreateSnsEventDownloadMutation.ts
+++ b/src/api/sns-event-assistant/post/mutations/useCreateSnsEventDownloadMutation.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { notFound, useRouter } from 'next/navigation';
+
+import { useMutation } from '@tanstack/react-query';
+
+import {
+  GetSnsEventAssistantListDownloadRequestDto,
+  GetSnsEventAssistantListDownloadResponseDto,
+} from '@api/sns-event-assistant/api.types';
+
+import { ApiErrorBody } from '@common/types/api.common.types';
+
+import { API_ERROR_CODES } from '@common/constants/api-error-codes.constants';
+
+import { ApiError } from '@common/errors/ApiError';
+
+import { CreateSnsEventDownload } from '../apis/create-sns-event-list-download';
+
+const useCreateSnsEventDownloadMutation = () => {
+  const router = useRouter();
+  return useMutation<
+    { result: GetSnsEventAssistantListDownloadResponseDto }, // TData
+    ApiError<ApiErrorBody>, // TError
+    GetSnsEventAssistantListDownloadRequestDto // TMutateVariables
+  >({
+    mutationFn: ({ snsEventId, format, listType }) => {
+      console.log(snsEventId, format, listType);
+      return CreateSnsEventDownload({ snsEventId, format, listType });
+    },
+    onSuccess: () => {
+      router.back();
+    },
+    onError: (error) => {
+      if (error.code === API_ERROR_CODES.SNS_EVENT.NOT_FOUND) {
+        notFound();
+      }
+    },
+  });
+};
+
+export default useCreateSnsEventDownloadMutation;

--- a/src/api/sns-event-assistant/post/mutations/useCreateSnsEventDownloadMutation.ts
+++ b/src/api/sns-event-assistant/post/mutations/useCreateSnsEventDownloadMutation.ts
@@ -17,6 +17,13 @@ import { ApiError } from '@common/errors/ApiError';
 
 import { CreateSnsEventDownload } from '../apis/create-sns-event-list-download';
 
+/**
+ * SNS 이벤트 목록 다운로드 요청을 위한 TanStack Query 뮤테이션 훅입니다.
+ * 훅의 `mutate` 함수는 GetSnsEventAssistantListDownloadRequestDto 타입의 객체를 전달받습니다.
+ * @param {string} mutationVariables.snsEventId - 다운로드할 SNS 이벤트의 고유 ID입니다.
+ * @param {DownloadFormat} mutationVariables.format - 다운로드할 파일의 형식입니다.
+ * @param {SnsEventAssistantListType} mutationVariables.listType - 다운로드할 목록의 타입입니다.
+ */
 const useCreateSnsEventDownloadMutation = () => {
   const router = useRouter();
   return useMutation<

--- a/src/api/sns-event-assistant/post/mutations/useCreateSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/post/mutations/useCreateSnsEventMutation.ts
@@ -23,6 +23,14 @@ import { useToastActions } from '@common/hooks/stores/useToastStore';
 
 import { CreateSnsEvent } from '../apis/create-sns-event';
 
+/**
+ * 새로운 SNS 이벤트를 생성하기 위한 TanStack Query 뮤테이션 훅입니다.
+ * 훅의 `mutate` 함수는 CreateSnsEventAssistantRequestDto 타입의 객체를 전달받습니다.
+ * @param {string} workspaceId - 이벤트가 생성될 워크스페이스의 고유 ID입니다.
+ * @param {string} mutationVariables.title - 새로운 이벤트의 제목입니다.
+ * @param {string} mutationVariables.snsEventLink - SNS 이벤트의 원본 링크입니다.
+ * @param {SnsEventAssistantCondition} mutationVariables.snsCondition - 이벤트 추첨 조건을 정의하는 객체입니다.
+ */
 const useCreateSnsEventMutation = (workspaceId: string) => {
   const queryClient = useQueryClient();
   const router = useRouter();

--- a/src/api/sns-event-assistant/post/mutations/useCreateSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/post/mutations/useCreateSnsEventMutation.ts
@@ -1,6 +1,8 @@
-import { notFound } from 'next/navigation';
+'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { notFound, useRouter } from 'next/navigation';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import {
   CreateSnsEventAssistantRequestDto,
@@ -10,12 +12,19 @@ import {
 import { ApiErrorBody } from '@common/types/api.common.types';
 
 import { API_ERROR_CODES } from '@common/constants/api-error-codes.constants';
+import queryKeys from '@common/constants/query-key.constants';
+import { ROUTES } from '@common/constants/routes.constants';
 
 import { ApiError } from '@common/errors/ApiError';
 
+import { useSnsEventAssistantActions } from '@common/hooks/stores/useSnsEventAssistantStore';
+
 import { CreateSnsEvent } from '../apis/create-sns-event';
 
-const useCreateSnsEventMutation = () => {
+const useCreateSnsEventMutation = (workspaceId: string) => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { setNewEventInit } = useSnsEventAssistantActions();
   return useMutation<
     { result: CreateSnsEventAssistantResponseDto }, // TData
     ApiError<ApiErrorBody>, // TError
@@ -23,6 +32,14 @@ const useCreateSnsEventMutation = () => {
   >({
     mutationFn: ({ workspaceId, title, snsEventLink, snsCondition }) =>
       CreateSnsEvent({ workspaceId, title, snsEventLink, snsCondition }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.snsEventAssistant.list(workspaceId).queryKey,
+      });
+      const snsEventId = data?.result?.snsEventId;
+      router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId));
+      setNewEventInit();
+    },
     onError: (error) => {
       if (error.code === API_ERROR_CODES.SNS_EVENT.NOT_FOUND) {
         notFound();

--- a/src/api/sns-event-assistant/post/mutations/useCreateSnsEventMutation.ts
+++ b/src/api/sns-event-assistant/post/mutations/useCreateSnsEventMutation.ts
@@ -10,6 +10,7 @@ import {
 } from '@api/sns-event-assistant/api.types';
 
 import { ApiErrorBody } from '@common/types/api.common.types';
+import { ToastType } from '@common/types/toast.types';
 
 import { API_ERROR_CODES } from '@common/constants/api-error-codes.constants';
 import queryKeys from '@common/constants/query-key.constants';
@@ -18,6 +19,7 @@ import { ROUTES } from '@common/constants/routes.constants';
 import { ApiError } from '@common/errors/ApiError';
 
 import { useSnsEventAssistantActions } from '@common/hooks/stores/useSnsEventAssistantStore';
+import { useToastActions } from '@common/hooks/stores/useToastStore';
 
 import { CreateSnsEvent } from '../apis/create-sns-event';
 
@@ -25,6 +27,7 @@ const useCreateSnsEventMutation = (workspaceId: string) => {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { setNewEventInit } = useSnsEventAssistantActions();
+  const { addToast } = useToastActions();
   return useMutation<
     { result: CreateSnsEventAssistantResponseDto }, // TData
     ApiError<ApiErrorBody>, // TError
@@ -43,6 +46,14 @@ const useCreateSnsEventMutation = (workspaceId: string) => {
     onError: (error) => {
       if (error.code === API_ERROR_CODES.SNS_EVENT.NOT_FOUND) {
         notFound();
+      } else {
+        router.back();
+        if (error.code === API_ERROR_CODES.SNS_EVENT.LINK_NOT_FOUND) {
+          addToast({
+            text: '올바른 링크를 입력해주세요.',
+            type: ToastType.ERROR,
+          });
+        }
       }
     },
   });

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/@snsEventAssistantGeneralModal/(.)[snsEventId]/download/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/@snsEventAssistantGeneralModal/(.)[snsEventId]/download/page.tsx
@@ -1,5 +1,13 @@
-const page = () => {
-  return <div></div>;
+import { Suspense } from 'react';
+
+import DownloadModalClient from '@features/sns-event-assistant/components/modal-client/DownLoadModalClient/DownloadModalClient';
+
+const DownloadPage = () => {
+  return (
+    <Suspense fallback={<div>로딩중...</div>}>
+      <DownloadModalClient />
+    </Suspense>
+  );
 };
 
-export default page;
+export default DownloadPage;

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/@snsEventAssistantGeneralModal/(.)delete/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/@snsEventAssistantGeneralModal/(.)delete/page.tsx
@@ -1,5 +1,13 @@
-const page = () => {
-  return <div></div>;
+import { Suspense } from 'react';
+
+import DeleteEventModalClient from '@features/sns-event-assistant/components/modal-client/DeleteEventModalClient/DeleteEventModalClient';
+
+const DeleteModalPage = () => {
+  return (
+    <Suspense fallback={<div>로딩중...</div>}>
+      <DeleteEventModalClient />
+    </Suspense>
+  );
 };
 
-export default page;
+export default DeleteModalPage;

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/@snsEventAssistantGeneralModal/[...catchAll]/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/@snsEventAssistantGeneralModal/[...catchAll]/page.tsx
@@ -1,0 +1,5 @@
+const CatchAllPage = () => {
+  return null;
+};
+
+export default CatchAllPage;

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
@@ -12,6 +12,8 @@ import useUpdateSnsEventMutation from '@api/sns-event-assistant/patch/mutations/
 
 import { GnbSection } from '@common/types/gnbs.types';
 
+import { ROUTES } from '@common/constants/routes.constants';
+
 import CategoryOption from '@common/components/CategoryOption/CategoryOption.client';
 import FileCreatedInfo from '@common/components/FileCreatedInfo/FileCreatedInfo.client';
 import RosterList from '@common/components/RosterList/RosterList.server';
@@ -22,37 +24,6 @@ import { InputFileTitleMode } from '@common/components/inputs/InputFileTitle/Inp
 
 import SnsLinkItem from '@features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client';
 
-const mockItems = [
-  {
-    userId: 'user1',
-  },
-  {
-    userId: 'user2',
-  },
-  {
-    userId: 'user3',
-  },
-  {
-    userId: 'user4',
-  },
-  {
-    userId: 'user5',
-  },
-  {
-    userId: 'user6',
-  },
-];
-const mockWinnerItems = [
-  {
-    userId: 'user1',
-  },
-  {
-    userId: 'user2',
-  },
-  {
-    userId: 'user3',
-  },
-];
 enum SnsCategory {
   PARTICIPANT = 'PARTICIPANT',
   WINNER = 'WINNER',
@@ -62,27 +33,28 @@ enum SnsCategory {
 const SnsEventAssistantDetailPage = () => {
   const [mode, setMode] = useState<InputFileTitleMode>(InputFileTitleMode.DEFAULT);
   const type = useSearchParams().get('type');
-  const { workspaceId, snsEventId } = useParams<{ workspaceId?: string; snsEventId?: string }>();
+  const { workspaceId, snsEventId } = useParams<{ workspaceId: string; snsEventId: string }>();
   const router = useRouter();
-  const items = type === SnsCategory.WINNER ? mockWinnerItems : mockItems;
+  const { extra: sns } = useSnsEvent(snsEventId);
+  const items = type === SnsCategory.WINNER ? sns?.winnerList : sns?.participantList;
+  const leftItems = items?.filter((_, index) => index < items.length / 2) ?? [];
+  const rightItems = items?.filter((_, index) => index >= items.length / 2) ?? [];
   const handleClick = (type: SnsCategory) => {
-    router.push(`/workspace/${workspaceId}/sns-event-assistant/${snsEventId}?type=${type}`);
+    router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId, type));
   };
   const [title, setTitle] = useState<string>('');
-
-  const { extra: sns } = useSnsEvent(snsEventId || '');
 
   useEffect(() => {
     if (sns?.title !== title) {
       setTitle(sns?.title ?? '');
     }
-  }, [sns]);
+  }, [sns, title]);
 
   const { mutate } = useUpdateSnsEventMutation();
   const handleTitleSave = (newTitle: string) => {
     console.log(snsEventId, newTitle);
     mutate(
-      { snsEventId: snsEventId || '', title: newTitle },
+      { snsEventId, title: newTitle },
       {
         onSuccess: () => {
           if (!newTitle) return;
@@ -100,20 +72,24 @@ const SnsEventAssistantDetailPage = () => {
           <div className="w-668pxr">
             <div className="gap-16pxr mt-24pxr flex flex-col">
               <InputFileTitle value={title} onSave={handleTitleSave} mode={mode} onMode={setMode} />
-              <FileCreatedInfo name={'이름'} userId={'id'} dateTime={new Date().toISOString()} />
+              <FileCreatedInfo
+                name={sns?.creatorName ?? ''}
+                userId={sns?.creatorId ?? ''}
+                dateTime={''}
+              />
             </div>
             <div className="mt-23pxr mb-13pxr flex w-full justify-between">
               <div className="gap-x-8pxr flex">
                 <CategoryOption
                   label="참여자 리스트"
                   active={type === SnsCategory.PARTICIPANT || !type}
-                  count={1}
+                  count={sns?.participantList?.length ?? 0}
                   onClick={() => handleClick(SnsCategory.PARTICIPANT)}
                 />
                 <CategoryOption
                   label="당첨자 리스트"
                   active={type === SnsCategory.WINNER}
-                  count={1}
+                  count={sns?.winnerList?.length ?? 0}
                   onClick={() => handleClick(SnsCategory.WINNER)}
                 />
                 <CategoryOption
@@ -136,11 +112,11 @@ const SnsEventAssistantDetailPage = () => {
         {/* 하단 부분 */}
         <div className="mt-28pxr flex w-full justify-center">
           {type == SnsCategory.LINK ? (
-            <SnsLinkItem title="Link Title" link="https://example.com" onClick={() => {}} />
+            <SnsLinkItem title={title} link={sns?.snsLink ?? ''} onClick={() => {}} />
           ) : (
             <>
-              <RosterList items={items} />
-              <RosterList items={items} hasLeftBorder={true} />
+              <RosterList items={leftItems ?? []} />
+              <RosterList items={rightItems ?? []} hasLeftBorder={true} />
             </>
           )}
         </div>

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
@@ -2,42 +2,21 @@
 
 import { useEffect, useState } from 'react';
 
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useParams } from 'next/navigation';
 
 import useSnsEvent from '@api/sns-event-assistant/get/queries/useSnsEvent';
 import useUpdateSnsEventMutation from '@api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation';
 
-import { SnsEventAssistantListType } from '@common/types/download.enum.types';
 import { GnbSection } from '@common/types/gnbs.types';
-import { ToastType } from '@common/types/toast.types';
 
-import { ROUTES } from '@common/constants/routes.constants';
-
-import { useToastActions } from '@common/hooks/stores/useToastStore';
-
-import CategoryOption from '@common/components/CategoryOption/CategoryOption.client';
-import FileCreatedInfo from '@common/components/FileCreatedInfo/FileCreatedInfo.client';
-import RosterList from '@common/components/RosterList/RosterList.server';
-import DownloadButton from '@common/components/buttons/30px/DownloadButton/DownloadButton.client';
 import GnbTop from '@common/components/gnbs/GnbTop/GnbTop.client';
-import InputFileTitle from '@common/components/inputs/InputFileTitle/InputFileTitle.client';
-import { InputFileTitleMode } from '@common/components/inputs/InputFileTitle/InputFileTitle.types';
 
-import CopyButton from '@features/sns-event-assistant/components/CopyButton/CopyButton.client';
-import SnsLinkItem from '@features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client';
+import SnsDetailMain from '@features/sns-event-assistant/components/SnsDetailMain/SnsDetailMain.client';
 
 const SnsEventAssistantDetailPage = () => {
-  const [mode, setMode] = useState<InputFileTitleMode>(InputFileTitleMode.DEFAULT);
-  const type = useSearchParams().get('type') as SnsEventAssistantListType;
-  const { workspaceId, snsEventId } = useParams<{ workspaceId: string; snsEventId: string }>();
-  const router = useRouter();
+  const { snsEventId } = useParams<{ snsEventId: string }>();
   const { extra: sns } = useSnsEvent(snsEventId);
-  const items = type === SnsEventAssistantListType.WINNER ? sns?.winnerList : sns?.participantList;
-  const leftItems = items?.filter((_, index) => index < items.length / 2) ?? [];
-  const rightItems = items?.filter((_, index) => index >= items.length / 2) ?? [];
   const [title, setTitle] = useState<string>('');
-  const { addToast } = useToastActions();
-
   useEffect(() => {
     if (sns?.title !== title) {
       setTitle(sns?.title ?? '');
@@ -46,7 +25,6 @@ const SnsEventAssistantDetailPage = () => {
 
   const { mutate } = useUpdateSnsEventMutation();
   const handleTitleSave = (newTitle: string) => {
-    console.log(snsEventId, newTitle);
     mutate(
       { snsEventId, title: newTitle },
       {
@@ -57,80 +35,11 @@ const SnsEventAssistantDetailPage = () => {
       },
     );
   };
-  const handleToggleClick = (type: SnsEventAssistantListType) => {
-    router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId, type));
-  };
-  const handleCopyClick = () => {
-    addToast({
-      text: '링크가 복사되었습니다.',
-      type: ToastType.SUCCESS,
-    });
-  };
   return (
     <section>
       <GnbTop section={GnbSection.CUSTOM} title={title} />
       <div className="flex w-full flex-col">
-        {/* 상단 부분 */}
-        <div className="border-b-stroke-200 flex w-full justify-center border-b border-solid bg-white">
-          <div className="w-668pxr">
-            <div className="gap-16pxr mt-24pxr flex flex-col">
-              <InputFileTitle value={title} onSave={handleTitleSave} mode={mode} onMode={setMode} />
-              <FileCreatedInfo
-                name={sns?.creatorName ?? ''}
-                userId={sns?.creatorId ?? ''}
-                dateTime={''}
-              />
-            </div>
-            <div className="mt-23pxr mb-13pxr flex w-full justify-between">
-              <div className="gap-x-8pxr flex">
-                <CategoryOption
-                  label="참여자 리스트"
-                  active={type === SnsEventAssistantListType.PARTICIPANT || !type}
-                  count={sns?.participantList?.length ?? 0}
-                  onClick={() => handleToggleClick(SnsEventAssistantListType.PARTICIPANT)}
-                />
-                <CategoryOption
-                  label="당첨자 리스트"
-                  active={type === SnsEventAssistantListType.WINNER}
-                  count={sns?.winnerList?.length ?? 0}
-                  onClick={() => handleToggleClick(SnsEventAssistantListType.WINNER)}
-                />
-                <CategoryOption
-                  label="SNS 링크"
-                  active={type === SnsEventAssistantListType.LINK}
-                  onClick={() => handleToggleClick(SnsEventAssistantListType.LINK)}
-                />
-              </div>
-              {type !== SnsEventAssistantListType.LINK && (
-                <div className="gap-x-12pxr flex items-center">
-                  <CopyButton onClick={handleCopyClick} />
-                  <DownloadButton
-                    onClick={() =>
-                      router.push(
-                        ROUTES.SNS_EVENT_ASSISTANT.DOWNLOAD(workspaceId, snsEventId, type),
-                      )
-                    }
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-        {/* 하단 부분 */}
-        <div className="mt-28pxr flex w-full justify-center">
-          {type == SnsEventAssistantListType.LINK ? (
-            <SnsLinkItem title={title} link={sns?.snsLink ?? ''} onClick={handleCopyClick} />
-          ) : (
-            <>
-              <RosterList items={leftItems ?? []} />
-              <RosterList
-                items={rightItems ?? []}
-                hasLeftBorder={true}
-                startIndex={leftItems.length}
-              />
-            </>
-          )}
-        </div>
+        <SnsDetailMain snsEventId={snsEventId} sns={sns} onTitleSave={handleTitleSave} />
       </div>
     </section>
   );

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
@@ -4,15 +4,15 @@ import { useEffect, useState } from 'react';
 
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 
-import FeatureTabIcons from '@icons/FeatureTabIcons/FeatureTabIcons';
-import { FeatureTabIconsState } from '@icons/FeatureTabIcons/FeatureTabIcons.types';
-
 import useSnsEvent from '@api/sns-event-assistant/get/queries/useSnsEvent';
 import useUpdateSnsEventMutation from '@api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation';
 
 import { GnbSection } from '@common/types/gnbs.types';
+import { ToastType } from '@common/types/toast.types';
 
 import { ROUTES } from '@common/constants/routes.constants';
+
+import { useToastActions } from '@common/hooks/stores/useToastStore';
 
 import CategoryOption from '@common/components/CategoryOption/CategoryOption.client';
 import FileCreatedInfo from '@common/components/FileCreatedInfo/FileCreatedInfo.client';
@@ -22,6 +22,7 @@ import GnbTop from '@common/components/gnbs/GnbTop/GnbTop.client';
 import InputFileTitle from '@common/components/inputs/InputFileTitle/InputFileTitle.client';
 import { InputFileTitleMode } from '@common/components/inputs/InputFileTitle/InputFileTitle.types';
 
+import CopyButton from '@features/sns-event-assistant/components/CopyButton/CopyButton.client';
 import SnsLinkItem from '@features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client';
 
 enum SnsCategory {
@@ -39,10 +40,8 @@ const SnsEventAssistantDetailPage = () => {
   const items = type === SnsCategory.WINNER ? sns?.winnerList : sns?.participantList;
   const leftItems = items?.filter((_, index) => index < items.length / 2) ?? [];
   const rightItems = items?.filter((_, index) => index >= items.length / 2) ?? [];
-  const handleClick = (type: SnsCategory) => {
-    router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId, type));
-  };
   const [title, setTitle] = useState<string>('');
+  const { addToast } = useToastActions();
 
   useEffect(() => {
     if (sns?.title !== title) {
@@ -62,6 +61,15 @@ const SnsEventAssistantDetailPage = () => {
         },
       },
     );
+  };
+  const handleToggleClick = (type: SnsCategory) => {
+    router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId, type));
+  };
+  const handleCopyClick = () => {
+    addToast({
+      text: '링크가 복사되었습니다.',
+      type: ToastType.SUCCESS,
+    });
   };
   return (
     <section>
@@ -84,25 +92,23 @@ const SnsEventAssistantDetailPage = () => {
                   label="참여자 리스트"
                   active={type === SnsCategory.PARTICIPANT || !type}
                   count={sns?.participantList?.length ?? 0}
-                  onClick={() => handleClick(SnsCategory.PARTICIPANT)}
+                  onClick={() => handleToggleClick(SnsCategory.PARTICIPANT)}
                 />
                 <CategoryOption
                   label="당첨자 리스트"
                   active={type === SnsCategory.WINNER}
                   count={sns?.winnerList?.length ?? 0}
-                  onClick={() => handleClick(SnsCategory.WINNER)}
+                  onClick={() => handleToggleClick(SnsCategory.WINNER)}
                 />
                 <CategoryOption
                   label="SNS 링크"
                   active={type === SnsCategory.LINK}
-                  onClick={() => handleClick(SnsCategory.LINK)}
+                  onClick={() => handleToggleClick(SnsCategory.LINK)}
                 />
               </div>
               {type !== SnsCategory.LINK && (
                 <div className="gap-x-12pxr flex items-center">
-                  <div className="cursor-pointer" onClick={() => {}}>
-                    <FeatureTabIcons state={FeatureTabIconsState.COPY} />
-                  </div>
+                  <CopyButton onClick={handleCopyClick} />
                   <DownloadButton onClick={() => {}} />
                 </div>
               )}
@@ -112,7 +118,7 @@ const SnsEventAssistantDetailPage = () => {
         {/* 하단 부분 */}
         <div className="mt-28pxr flex w-full justify-center">
           {type == SnsCategory.LINK ? (
-            <SnsLinkItem title={title} link={sns?.snsLink ?? ''} onClick={() => {}} />
+            <SnsLinkItem title={title} link={sns?.snsLink ?? ''} onClick={handleCopyClick} />
           ) : (
             <>
               <RosterList items={leftItems ?? []} />

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/[snsEventId]/page.tsx
@@ -7,6 +7,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import useSnsEvent from '@api/sns-event-assistant/get/queries/useSnsEvent';
 import useUpdateSnsEventMutation from '@api/sns-event-assistant/patch/mutations/useUpdateSnsEventMutation';
 
+import { SnsEventAssistantListType } from '@common/types/download.enum.types';
 import { GnbSection } from '@common/types/gnbs.types';
 import { ToastType } from '@common/types/toast.types';
 
@@ -25,19 +26,13 @@ import { InputFileTitleMode } from '@common/components/inputs/InputFileTitle/Inp
 import CopyButton from '@features/sns-event-assistant/components/CopyButton/CopyButton.client';
 import SnsLinkItem from '@features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client';
 
-enum SnsCategory {
-  PARTICIPANT = 'PARTICIPANT',
-  WINNER = 'WINNER',
-  LINK = 'LINK',
-}
-
 const SnsEventAssistantDetailPage = () => {
   const [mode, setMode] = useState<InputFileTitleMode>(InputFileTitleMode.DEFAULT);
-  const type = useSearchParams().get('type');
+  const type = useSearchParams().get('type') as SnsEventAssistantListType;
   const { workspaceId, snsEventId } = useParams<{ workspaceId: string; snsEventId: string }>();
   const router = useRouter();
   const { extra: sns } = useSnsEvent(snsEventId);
-  const items = type === SnsCategory.WINNER ? sns?.winnerList : sns?.participantList;
+  const items = type === SnsEventAssistantListType.WINNER ? sns?.winnerList : sns?.participantList;
   const leftItems = items?.filter((_, index) => index < items.length / 2) ?? [];
   const rightItems = items?.filter((_, index) => index >= items.length / 2) ?? [];
   const [title, setTitle] = useState<string>('');
@@ -62,7 +57,7 @@ const SnsEventAssistantDetailPage = () => {
       },
     );
   };
-  const handleToggleClick = (type: SnsCategory) => {
+  const handleToggleClick = (type: SnsEventAssistantListType) => {
     router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId, type));
   };
   const handleCopyClick = () => {
@@ -90,26 +85,32 @@ const SnsEventAssistantDetailPage = () => {
               <div className="gap-x-8pxr flex">
                 <CategoryOption
                   label="참여자 리스트"
-                  active={type === SnsCategory.PARTICIPANT || !type}
+                  active={type === SnsEventAssistantListType.PARTICIPANT || !type}
                   count={sns?.participantList?.length ?? 0}
-                  onClick={() => handleToggleClick(SnsCategory.PARTICIPANT)}
+                  onClick={() => handleToggleClick(SnsEventAssistantListType.PARTICIPANT)}
                 />
                 <CategoryOption
                   label="당첨자 리스트"
-                  active={type === SnsCategory.WINNER}
+                  active={type === SnsEventAssistantListType.WINNER}
                   count={sns?.winnerList?.length ?? 0}
-                  onClick={() => handleToggleClick(SnsCategory.WINNER)}
+                  onClick={() => handleToggleClick(SnsEventAssistantListType.WINNER)}
                 />
                 <CategoryOption
                   label="SNS 링크"
-                  active={type === SnsCategory.LINK}
-                  onClick={() => handleToggleClick(SnsCategory.LINK)}
+                  active={type === SnsEventAssistantListType.LINK}
+                  onClick={() => handleToggleClick(SnsEventAssistantListType.LINK)}
                 />
               </div>
-              {type !== SnsCategory.LINK && (
+              {type !== SnsEventAssistantListType.LINK && (
                 <div className="gap-x-12pxr flex items-center">
                   <CopyButton onClick={handleCopyClick} />
-                  <DownloadButton onClick={() => {}} />
+                  <DownloadButton
+                    onClick={() =>
+                      router.push(
+                        ROUTES.SNS_EVENT_ASSISTANT.DOWNLOAD(workspaceId, snsEventId, type),
+                      )
+                    }
+                  />
                 </div>
               )}
             </div>
@@ -117,12 +118,16 @@ const SnsEventAssistantDetailPage = () => {
         </div>
         {/* 하단 부분 */}
         <div className="mt-28pxr flex w-full justify-center">
-          {type == SnsCategory.LINK ? (
+          {type == SnsEventAssistantListType.LINK ? (
             <SnsLinkItem title={title} link={sns?.snsLink ?? ''} onClick={handleCopyClick} />
           ) : (
             <>
               <RosterList items={leftItems ?? []} />
-              <RosterList items={rightItems ?? []} hasLeftBorder={true} />
+              <RosterList
+                items={rightItems ?? []}
+                hasLeftBorder={true}
+                startIndex={leftItems.length}
+              />
             </>
           )}
         </div>

--- a/src/app/workspace/[workspaceId]/sns-event-assistant/page.tsx
+++ b/src/app/workspace/[workspaceId]/sns-event-assistant/page.tsx
@@ -23,12 +23,14 @@ const SnsEventAssistantDefaultPage = async ({
   const { snsGnbTab } = await searchParams;
 
   const formattedSnsGnbTab = parseEnumOr404(snsGnbTab, SnsGnbTabType, SnsGnbTabType.ALL_EVENTS);
+
   return (
     <section>
       <GnbTop section={GnbSection.SNS_EVENT_ASSISTANT} current={formattedSnsGnbTab} />
       <div className="assistant-wrapper">
         {formattedSnsGnbTab === SnsGnbTabType.ALL_EVENTS ? (
           <>
+            {/* 전체 이벤트 */}
             {/* cta 부분 */}
             {getCtaDescription(FileType.SNS_EVENT_ASSISTANT)}
             <TextCtaWrapper workspaceId={workspaceId} fileType={FileType.SNS_EVENT_ASSISTANT} />
@@ -38,6 +40,7 @@ const SnsEventAssistantDefaultPage = async ({
           </>
         ) : (
           <>
+            {/* SNS 링크 관리 부분 */}
             {/* 리스트 부분 */}
             {getListTitle(SNS_EVENT_ASSISTANT_LINK)}
             <ListHeader fileType={SNS_EVENT_ASSISTANT_LINK} />

--- a/src/common/components/RosterList/RosterList.server.tsx
+++ b/src/common/components/RosterList/RosterList.server.tsx
@@ -11,8 +11,8 @@ const RosterList = ({ items, hasLeftBorder = false, startIndex = 0 }: RosterList
           const rowNumber = startIndex + index + 1;
           return (
             <RosterDataField
-              key={item.userId + index}
-              userId={item.userId}
+              key={item.account + index}
+              userId={item.account}
               index={index}
               rowNumber={rowNumber}
               hasLeftBorder={hasLeftBorder}

--- a/src/common/components/RosterList/RosterList.stories.tsx
+++ b/src/common/components/RosterList/RosterList.stories.tsx
@@ -14,12 +14,16 @@ const meta: Meta<typeof RosterList> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * 백엔드에서 userId -> account로 변경 됨
+ */
+
 const mockItems = [
-  { userId: 'SSOXX_A' },
-  { userId: 'SSOXX_B' },
-  { userId: 'SSOXX_C' },
-  { userId: 'SSOXX_D' },
-  { userId: 'SSOXX_E' },
+  { account: 'SSOXX_A' },
+  { account: 'SSOXX_B' },
+  { account: 'SSOXX_C' },
+  { account: 'SSOXX_D' },
+  { account: 'SSOXX_E' },
 ];
 
 export const Default: Story = {
@@ -61,11 +65,11 @@ export const WithLongUserId: Story = {
   name: '긴 userId 포함',
   args: {
     items: [
-      { userId: 'SSOXX_A' },
-      { userId: 'SSOXX_B' },
-      { userId: 'THIS_IS_A_SUPER_LONG_USER_IDENTIFIER_TO_TEST_TEXT_TRUNCATION_OVER_290PX_WIDTH' },
-      { userId: 'SSOXX_D' },
-      { userId: 'SSOXX_E' },
+      { account: 'SSOXX_A' },
+      { account: 'SSOXX_B' },
+      { account: 'THIS_IS_A_SUPER_LONG_USER_IDENTIFIER_TO_TEST_TEXT_TRUNCATION_OVER_290PX_WIDTH' },
+      { account: 'SSOXX_D' },
+      { account: 'SSOXX_E' },
     ],
     hasLeftBorder: false,
     startIndex: 0,

--- a/src/common/components/RosterList/RosterList.types.ts
+++ b/src/common/components/RosterList/RosterList.types.ts
@@ -1,5 +1,7 @@
+import { PeopleList } from '@api/sns-event-assistant/api.types';
+
 export interface RosterListProps {
-  items: { userId: string }[];
+  items: PeopleList[];
   hasLeftBorder?: boolean;
   startIndex?: number;
 }

--- a/src/common/components/list-file/ListFileSnsEventAssistantLink/ListFileSnsEventAssistantLink.client.tsx
+++ b/src/common/components/list-file/ListFileSnsEventAssistantLink/ListFileSnsEventAssistantLink.client.tsx
@@ -1,8 +1,12 @@
 'use client';
 
+import { useParams } from 'next/navigation';
+
 import FeatureTabIcons from '@icons/FeatureTabIcons/FeatureTabIcons';
 import { FeatureTabIconsState } from '@icons/FeatureTabIcons/FeatureTabIcons.types';
 import { FeaturedFileIconsState } from '@icons/FeaturedFileIcons/FeaturedFileIcons.types';
+
+import { ROUTES } from '@common/constants/routes.constants';
 
 import BaseListFile from '../BaseListFile/BaseListFile.client';
 import { ListFileSnsEventAssistantLinkProps } from './ListFileSnsEventAssistantLink.types';
@@ -13,6 +17,7 @@ const ListFileSnsEventAssistantLink = ({
   updatedAt,
   snsLink,
 }: ListFileSnsEventAssistantLinkProps) => {
+  const { workspaceId } = useParams<{ workspaceId: string }>();
   const rightContent = (
     <div className="text-b3-rg w-330pxr gap-3pxr flex cursor-pointer items-center">
       <FeatureTabIcons state={FeatureTabIconsState.COPY} className="mr-1pxr" />
@@ -33,7 +38,7 @@ const ListFileSnsEventAssistantLink = ({
       id={snsEventId}
       title={title}
       subtitle={updatedAt}
-      href={`/meeting/${snsEventId}`}
+      href={ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId)}
       fileIconState={FeaturedFileIconsState.SIZE_24_SNS_ASSISTANT_FILE}
       rightContent={rightContent}
       isSelectable={false}

--- a/src/common/components/modals/CreateNewEventModal/CreateNewEventModal.client.tsx
+++ b/src/common/components/modals/CreateNewEventModal/CreateNewEventModal.client.tsx
@@ -169,12 +169,6 @@ const CreateNewEventModal = ({ onClose, onNextStep }: CreateNewEventModalProps) 
             className="mt-3pxr"
           />
           {keyword.isActive && (
-            // <InputFieldModal
-            //   placeholder="키워드를 입력해 주세요."
-            //   value={keyword}
-            //   onChange={setKeyword}
-            //   className="mt-8pxr"
-            // />
             <InputChips
               inputChips={keyword.keyword}
               placeholder="키워드를 입력해 주세요."

--- a/src/common/components/modals/CreateNewEventModal/CreateNewEventModal.client.tsx
+++ b/src/common/components/modals/CreateNewEventModal/CreateNewEventModal.client.tsx
@@ -44,7 +44,7 @@ const CreateNewEventModal = ({ onClose, onNextStep }: CreateNewEventModalProps) 
     if (temporaryDate) {
       setPeriod(temporaryDate);
     }
-  }, [temporaryDate]);
+  }, [temporaryDate, setPeriod]);
 
   /**
    * 당첨 인원 수 변경 핸들러

--- a/src/common/constants/gnbs.constants.ts
+++ b/src/common/constants/gnbs.constants.ts
@@ -36,7 +36,7 @@ export const GnbLeftNavItems: GnbLeftSection[] = [
 export const GnbSectionPaths = (workspaceId: BigintString) => ({
   [GnbSection.MAIN]: ROUTES.WORKSPACE_MAIN(workspaceId),
   [GnbSection.AI_MEETING_MANAGER]: ROUTES.AI_MEETING_MANAGER.BASE(workspaceId),
-  [GnbSection.SNS_EVENT_ASSISTANT]: ROUTES.SNS_EVENT_ASSISTANT(workspaceId),
+  [GnbSection.SNS_EVENT_ASSISTANT]: ROUTES.SNS_EVENT_ASSISTANT.MAIN(workspaceId),
   [GnbSection.TEAM_MOOD_TRACKER]: ROUTES.TEAM_MOOD_TRACKER.MAIN(workspaceId),
   [GnbSection.CALENDAR]: ROUTES.CALENDAR(workspaceId),
 });

--- a/src/common/constants/routes.constants.ts
+++ b/src/common/constants/routes.constants.ts
@@ -60,6 +60,8 @@ export const ROUTES = {
       `/workspace/${workspaceId}/sns-event-assistant/${snsEventId}${type ? `?type=${type}` : ''}`,
     CREATE: (workspaceId: string) => `/workspace/${workspaceId}/sns-event-assistant/creating-event`,
     DELETE: (workspaceId: string) => `/workspace/${workspaceId}/sns-event-assistant/delete`,
+    DOWNLOAD: (workspaceId: string, snsEventId: string, type?: string) =>
+      `/workspace/${workspaceId}/sns-event-assistant/${snsEventId}/download${type ? `?type=${type}` : ''}`,
   },
   TEAM_MOOD_TRACKER: {
     MAIN: (workspaceId: BigintString) => `/workspace/${workspaceId}/team-mood-tracker`,

--- a/src/common/constants/routes.constants.ts
+++ b/src/common/constants/routes.constants.ts
@@ -56,8 +56,8 @@ export const ROUTES = {
   //  ===== sns event assistant 관련 =====
   SNS_EVENT_ASSISTANT: {
     MAIN: (workspaceId: BigintString) => `/workspace/${workspaceId}/sns-event-assistant`,
-    DETAIL: (workspaceId: string, snsEventId: string) =>
-      `/workspace/${workspaceId}/sns-event-assistant/${snsEventId}`,
+    DETAIL: (workspaceId: string, snsEventId: string, type?: string) =>
+      `/workspace/${workspaceId}/sns-event-assistant/${snsEventId}${type ? `?type=${type}` : ''}`,
     CREATE: (workspaceId: string) => `/workspace/${workspaceId}/sns-event-assistant/creating-event`,
     DELETE: (workspaceId: string) => `/workspace/${workspaceId}/sns-event-assistant/delete`,
   },

--- a/src/common/constants/routes.constants.ts
+++ b/src/common/constants/routes.constants.ts
@@ -54,8 +54,13 @@ export const ROUTES = {
     },
   },
   //  ===== sns event assistant 관련 =====
-  SNS_EVENT_ASSISTANT: (workspaceId: BigintString) =>
-    `/workspace/${workspaceId}/sns-event-assistant`,
+  SNS_EVENT_ASSISTANT: {
+    MAIN: (workspaceId: BigintString) => `/workspace/${workspaceId}/sns-event-assistant`,
+    DETAIL: (workspaceId: string, snsEventId: string) =>
+      `/workspace/${workspaceId}/sns-event-assistant/${snsEventId}`,
+    CREATE: (workspaceId: string) => `/workspace/${workspaceId}/sns-event-assistant/creating-event`,
+    DELETE: (workspaceId: string) => `/workspace/${workspaceId}/sns-event-assistant/delete`,
+  },
   TEAM_MOOD_TRACKER: {
     MAIN: (workspaceId: BigintString) => `/workspace/${workspaceId}/team-mood-tracker`,
     DOCUMENT_PREFIX: (workspaceId: BigintString) =>

--- a/src/common/hooks/stores/useSnsEventAssistantStore.ts
+++ b/src/common/hooks/stores/useSnsEventAssistantStore.ts
@@ -7,6 +7,8 @@ export const useSnsEventAssistantInfo = () =>
     useShallow((state) => ({
       newTitle: state.newTitle,
       newSnsEventLink: state.newSnsEventLink,
+      checkedList: state.checkedList,
+      isCheckedMode: state.isCheckedMode,
       winnerCount: state.conditions.winnerCount,
       period: state.conditions.period,
       keyword: state.conditions.keyword,

--- a/src/common/stores/sns-event-assistant-store.ts
+++ b/src/common/stores/sns-event-assistant-store.ts
@@ -24,10 +24,15 @@ export interface SnsEventAssistantStoreState {
   newTitle: string;
   newSnsEventLink: string;
   conditions: EventConditions;
+  checkedList: string[];
+  isCheckedMode: boolean;
   actions: {
+    setNewEventInit: () => void;
     setNewTitle: (title: string) => void;
     setNewSnsEventLink: (link: string) => void;
     setConditions: (conditions: EventConditions) => void;
+    setCheckedList: (list: string[]) => void;
+    setIsCheckedMode: (isCheckedMode: boolean) => void;
     setWinnerCount: (count: number | null) => void;
     togglePeriod: () => void;
     toggleKeyword: () => void;
@@ -46,8 +51,19 @@ const snsEventAssistantStore = create<SnsEventAssistantStoreState>()(
     immer((set) => ({
       newTitle: '',
       newSnsEventLink: '',
+      checkedList: [],
+      isCheckedMode: false,
       conditions: DEFAULT_CONDITIONS,
       actions: {
+        setNewEventInit: () => {
+          set((state) => {
+            state.newTitle = '';
+            state.newSnsEventLink = '';
+            state.conditions = DEFAULT_CONDITIONS;
+            state.checkedList = [];
+            state.isCheckedMode = false;
+          });
+        },
         setNewTitle: (title) => {
           set((state) => {
             state.newTitle = title;
@@ -61,6 +77,16 @@ const snsEventAssistantStore = create<SnsEventAssistantStoreState>()(
         setConditions: (newConditions) => {
           set((state) => {
             state.conditions = newConditions;
+          });
+        },
+        setCheckedList: (list) => {
+          set((state) => {
+            state.checkedList = list;
+          });
+        },
+        setIsCheckedMode: (isCheckedMode) => {
+          set((state) => {
+            state.isCheckedMode = isCheckedMode;
           });
         },
         setWinnerCount: (count) => {

--- a/src/common/types/download.enum.types.ts
+++ b/src/common/types/download.enum.types.ts
@@ -1,4 +1,4 @@
-export enum Format {
+export enum DownloadFormat {
   PDF = 'PDF',
   DOCX = 'DOCX',
 }
@@ -6,4 +6,5 @@ export enum Format {
 export enum SnsEventAssistantListType {
   PARTICIPANT = 'PARTICIPANT',
   WINNER = 'WINNER',
+  LINK = 'LINK',
 }

--- a/src/common/utils/assistant-mapping.utils.tsx
+++ b/src/common/utils/assistant-mapping.utils.tsx
@@ -29,7 +29,7 @@ export const getListTitle = (type: ExtendedFileType) => {
     case FileType.AI_MEETING_MANAGER:
       return <BoldText text={'내 AI 회의록'} className={'mt-56pxr mb-16pxr'} />;
     case FileType.SNS_EVENT_ASSISTANT:
-      return <BoldText text={'내 이벤트 추첨 기록'} className={'mt-56pxr mb-16pxr'} />;
+      return <BoldText text={'내 이벤트 추첨 기록'} className={'mt-56pxr'} />;
     case FileType.TEAM_MOOD_TRACKER:
       return <BoldText text={'내 팀 분위기 리포트'} className={'mt-56pxr mb-16pxr'} />;
     case SNS_EVENT_ASSISTANT_LINK:

--- a/src/features/sns-event-assistant/components/CopyButton/CopyButton.client.tsx
+++ b/src/features/sns-event-assistant/components/CopyButton/CopyButton.client.tsx
@@ -5,6 +5,10 @@ import { FeatureTabIconsState } from '@icons/FeatureTabIcons/FeatureTabIcons.typ
 
 import { CopyButtonProps } from './CopyButton.types';
 
+/**
+ * 클립보드에 링크를 복사하는 버튼 컴포넌트입니다.
+ * link이 제공되지 않으면 현재 URL을 복사합니다.
+ */
 const CopyButton = ({ link, onClick, className, isHoverable = true }: CopyButtonProps) => {
   const handleClick = () => {
     if (link) {

--- a/src/features/sns-event-assistant/components/CopyButton/CopyButton.client.tsx
+++ b/src/features/sns-event-assistant/components/CopyButton/CopyButton.client.tsx
@@ -1,0 +1,33 @@
+import clsx from 'clsx';
+
+import FeatureTabIcons from '@icons/FeatureTabIcons/FeatureTabIcons';
+import { FeatureTabIconsState } from '@icons/FeatureTabIcons/FeatureTabIcons.types';
+
+import { CopyButtonProps } from './CopyButton.types';
+
+const CopyButton = ({ link, onClick, className, isHoverable = true }: CopyButtonProps) => {
+  const handleClick = () => {
+    if (link) {
+      navigator.clipboard.writeText(link);
+    } else {
+      navigator.clipboard.writeText(window.location.href);
+    }
+    onClick?.();
+  };
+  return (
+    <div
+      className={clsx(
+        'p-6pxr rounded-7pxr flex cursor-pointer items-center justify-center',
+        className,
+        {
+          'hover:bg-gray-600': isHoverable,
+        },
+      )}
+      onClick={handleClick}
+    >
+      <FeatureTabIcons state={FeatureTabIconsState.COPY} />
+    </div>
+  );
+};
+
+export default CopyButton;

--- a/src/features/sns-event-assistant/components/CopyButton/CopyButton.types.ts
+++ b/src/features/sns-event-assistant/components/CopyButton/CopyButton.types.ts
@@ -1,0 +1,8 @@
+import { ButtonsCommonProps } from '@common/components/buttons/types/buttons.common.types';
+
+export interface CopyButtonProps extends ButtonsCommonProps {
+  link?: string;
+  onClick?: () => void;
+  isHoverable?: boolean;
+  className?: string;
+}

--- a/src/features/sns-event-assistant/components/LinkText/LinkText.client.tsx
+++ b/src/features/sns-event-assistant/components/LinkText/LinkText.client.tsx
@@ -1,0 +1,16 @@
+import { LinkTextProps } from './LinkText.types';
+
+const LinkText = ({ text, className }: LinkTextProps) => {
+  return (
+    <a
+      href={text}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`hover:underline ${className}`}
+    >
+      {text}
+    </a>
+  );
+};
+
+export default LinkText;

--- a/src/features/sns-event-assistant/components/LinkText/LinkText.client.tsx
+++ b/src/features/sns-event-assistant/components/LinkText/LinkText.client.tsx
@@ -1,12 +1,18 @@
+import clsx from 'clsx';
+
 import { LinkTextProps } from './LinkText.types';
 
+/*
+ * LinkText 컴포넌트는 주어진 텍스트를 링크로 표시합니다.
+ * 링크는 새 탭에서 열리며, 언더바가 기본으로 표시됩니다.
+ */
 const LinkText = ({ text, className }: LinkTextProps) => {
   return (
     <a
       href={text}
       target="_blank"
       rel="noopener noreferrer"
-      className={`hover:underline ${className}`}
+      className={clsx('hover:underline', className)}
     >
       {text}
     </a>

--- a/src/features/sns-event-assistant/components/LinkText/LinkText.types.ts
+++ b/src/features/sns-event-assistant/components/LinkText/LinkText.types.ts
@@ -1,0 +1,4 @@
+export interface LinkTextProps {
+  text: string;
+  className?: string;
+}

--- a/src/features/sns-event-assistant/components/SnsDetailMain/SnsBodyList/SnsBodyList.client.tsx
+++ b/src/features/sns-event-assistant/components/SnsDetailMain/SnsBodyList/SnsBodyList.client.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { PeopleList } from '@api/sns-event-assistant/api.types';
+
+import { SnsEventAssistantListType } from '@common/types/download.enum.types';
+
+import RosterList from '@common/components/RosterList/RosterList.server';
+
+import SnsLinkItem from '../../SnsLinkItem/SnsLinkItem.client';
+
+interface SnsBodyListProps {
+  winnerList?: PeopleList[];
+  participantList?: PeopleList[];
+  type: SnsEventAssistantListType;
+  title?: string;
+  link?: string;
+  onCopyClick?: () => void;
+}
+const SnsBodyList = ({
+  winnerList,
+  participantList,
+  type,
+  link = '',
+  title = '',
+  onCopyClick,
+}: SnsBodyListProps) => {
+  const items = type === SnsEventAssistantListType.WINNER ? winnerList : participantList;
+  const leftItems = items?.filter((_, index) => index < items.length / 2) ?? [];
+  const rightItems = items?.filter((_, index) => index >= items.length / 2) ?? [];
+  return (
+    <div className="mt-28pxr flex w-full justify-center">
+      {type == SnsEventAssistantListType.LINK ? (
+        <SnsLinkItem title={title} link={link} onClick={onCopyClick} />
+      ) : (
+        <>
+          <RosterList items={leftItems ?? []} />
+          <RosterList items={rightItems ?? []} hasLeftBorder={true} startIndex={leftItems.length} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SnsBodyList;

--- a/src/features/sns-event-assistant/components/SnsDetailMain/SnsDetailMain.client.tsx
+++ b/src/features/sns-event-assistant/components/SnsDetailMain/SnsDetailMain.client.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+
+import { SnsEventAssistantObject } from '@api/sns-event-assistant/api.types';
+
+import { SnsEventAssistantListType } from '@common/types/download.enum.types';
+import { ToastType } from '@common/types/toast.types';
+
+import { useToastActions } from '@common/hooks/stores/useToastStore';
+
+import FileCreatedInfo from '@common/components/FileCreatedInfo/FileCreatedInfo.client';
+import InputFileTitle from '@common/components/inputs/InputFileTitle/InputFileTitle.client';
+import { InputFileTitleMode } from '@common/components/inputs/InputFileTitle/InputFileTitle.types';
+
+import SnsBodyList from './SnsBodyList/SnsBodyList.client';
+import SnsTopAction from './SnsTopAction/SnsTopAction.client';
+
+interface SnsDetailMainProps {
+  snsEventId?: string;
+  sns?: SnsEventAssistantObject;
+  onTitleSave?: (newTitle: string) => void;
+}
+const SnsDetailMain = ({ snsEventId, sns, onTitleSave }: SnsDetailMainProps) => {
+  const [mode, setMode] = useState<InputFileTitleMode>(InputFileTitleMode.DEFAULT);
+  const type = useSearchParams().get('type') as SnsEventAssistantListType;
+  const { addToast } = useToastActions();
+
+  const handleCopyClick = () => {
+    addToast({
+      text: '링크가 복사되었습니다.',
+      type: ToastType.SUCCESS,
+    });
+  };
+
+  const handleSaveTitle = (newTitle: string) => {
+    onTitleSave?.(newTitle);
+    setMode(InputFileTitleMode.DEFAULT);
+  };
+
+  return (
+    <>
+      {/* 상단 부분 */}
+      <div className="border-b-stroke-200 flex w-full justify-center border-b border-solid bg-white">
+        <div className="w-668pxr">
+          <div className="gap-16pxr mt-24pxr flex flex-col">
+            <InputFileTitle
+              value={sns?.title ?? ''}
+              onSave={handleSaveTitle}
+              mode={mode}
+              onRequestEdit={() => setMode(InputFileTitleMode.EDITABLE)}
+            />
+            <FileCreatedInfo
+              name={sns?.creatorName ?? ''}
+              userId={sns?.creatorId ?? ''}
+              dateTime={`${sns?.updatedAt}`}
+            />
+          </div>
+          <SnsTopAction
+            workspaceId={sns?.workspaceId ?? ''}
+            snsEventId={snsEventId ?? ''}
+            onCopyClick={handleCopyClick}
+            participantList={sns?.participantList}
+            winnerList={sns?.winnerList}
+            type={type}
+          />
+        </div>
+      </div>
+      {/* 하단 부분 */}
+      <SnsBodyList
+        link={sns?.snsLink}
+        onCopyClick={handleCopyClick}
+        participantList={sns?.participantList}
+        winnerList={sns?.winnerList}
+        title={sns?.title}
+        type={type}
+      />
+    </>
+  );
+};
+
+export default SnsDetailMain;

--- a/src/features/sns-event-assistant/components/SnsDetailMain/SnsTopAction/SnsTop.types.ts
+++ b/src/features/sns-event-assistant/components/SnsDetailMain/SnsTopAction/SnsTop.types.ts
@@ -1,0 +1,13 @@
+export interface SnsTopProps {
+  snsEventId: string;
+  snsLink: string;
+  title: string;
+  creatorId: string;
+  creatorName: string;
+  updatedAt: Date;
+  participantCount: number;
+  winnerCount: number;
+  isCreator?: boolean;
+  isParticipant?: boolean;
+  isWinner?: boolean;
+}

--- a/src/features/sns-event-assistant/components/SnsDetailMain/SnsTopAction/SnsTopAction.client.tsx
+++ b/src/features/sns-event-assistant/components/SnsDetailMain/SnsTopAction/SnsTopAction.client.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { PeopleList } from '@api/sns-event-assistant/api.types';
+
+import { SnsEventAssistantListType } from '@common/types/download.enum.types';
+
+import { ROUTES } from '@common/constants/routes.constants';
+
+import CategoryOption from '@common/components/CategoryOption/CategoryOption.client';
+import DownloadButton from '@common/components/buttons/30px/DownloadButton/DownloadButton.client';
+
+import CopyButton from '../../CopyButton/CopyButton.client';
+
+interface SnsTopActionProps {
+  workspaceId: string;
+  snsEventId: string;
+  onCopyClick: () => void;
+  participantList?: PeopleList[];
+  winnerList?: PeopleList[];
+  type?: SnsEventAssistantListType;
+}
+
+const SnsTopAction = ({
+  workspaceId,
+  snsEventId,
+  onCopyClick,
+  participantList = [],
+  winnerList = [],
+  type = SnsEventAssistantListType.PARTICIPANT,
+}: SnsTopActionProps) => {
+  const router = useRouter();
+  const handleToggleClick = (type: SnsEventAssistantListType) => {
+    router.push(ROUTES.SNS_EVENT_ASSISTANT.DETAIL(workspaceId, snsEventId, type));
+  };
+  return (
+    <div className="mt-23pxr mb-13pxr flex w-full justify-between">
+      <div className="gap-x-8pxr flex">
+        <CategoryOption
+          label="참여자 리스트"
+          active={type === SnsEventAssistantListType.PARTICIPANT || !type}
+          count={participantList.length}
+          onClick={() => handleToggleClick(SnsEventAssistantListType.PARTICIPANT)}
+        />
+        <CategoryOption
+          label="당첨자 리스트"
+          active={type === SnsEventAssistantListType.WINNER}
+          count={winnerList.length}
+          onClick={() => handleToggleClick(SnsEventAssistantListType.WINNER)}
+        />
+        <CategoryOption
+          label="SNS 링크"
+          active={type === SnsEventAssistantListType.LINK}
+          onClick={() => handleToggleClick(SnsEventAssistantListType.LINK)}
+        />
+      </div>
+      {type !== SnsEventAssistantListType.LINK && (
+        <div className="gap-x-12pxr flex items-center">
+          <CopyButton onClick={onCopyClick} />
+          <DownloadButton
+            onClick={() =>
+              router.push(ROUTES.SNS_EVENT_ASSISTANT.DOWNLOAD(workspaceId, snsEventId, type))
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SnsTopAction;

--- a/src/features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client.tsx
+++ b/src/features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client.tsx
@@ -1,6 +1,4 @@
-import FeatureTabIcons from '@icons/FeatureTabIcons/FeatureTabIcons';
-import { FeatureTabIconsState } from '@icons/FeatureTabIcons/FeatureTabIcons.types';
-
+import CopyButton from '../CopyButton/CopyButton.client';
 import { SnsLinkItemProps } from './SnsLinkItem.type';
 
 const SnsLinkItem = ({ title, link, onClick }: SnsLinkItemProps) => {
@@ -9,9 +7,7 @@ const SnsLinkItem = ({ title, link, onClick }: SnsLinkItemProps) => {
       <span className="text-t5-bd">{title}</span>
       <div className="flex items-center justify-between">
         <span className="text-t7-rg cursor-pointer hover:underline">{link}</span>
-        <div onClick={onClick} className="cursor-pointer">
-          <FeatureTabIcons state={FeatureTabIconsState.COPY} />
-        </div>
+        <CopyButton link={link} onClick={onClick} isHoverable={false} />
       </div>
     </div>
   );

--- a/src/features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client.tsx
+++ b/src/features/sns-event-assistant/components/SnsLinkItem/SnsLinkItem.client.tsx
@@ -1,4 +1,5 @@
 import CopyButton from '../CopyButton/CopyButton.client';
+import LinkText from '../LinkText/LinkText.client';
 import { SnsLinkItemProps } from './SnsLinkItem.type';
 
 const SnsLinkItem = ({ title, link, onClick }: SnsLinkItemProps) => {
@@ -6,7 +7,7 @@ const SnsLinkItem = ({ title, link, onClick }: SnsLinkItemProps) => {
     <div className="px-32pxr pb-24pxr pt-16pxr w-668pxr rounded-12pxr gap-y-3pxr flex flex-col justify-center bg-gray-700">
       <span className="text-t5-bd">{title}</span>
       <div className="flex items-center justify-between">
-        <span className="text-t7-rg cursor-pointer hover:underline">{link}</span>
+        <LinkText text={link} className="text-t7-rg" />
         <CopyButton link={link} onClick={onClick} isHoverable={false} />
       </div>
     </div>

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantLinkWrapper/ListFileSnsEventAssistantLinkWrapper.client.tsx
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantLinkWrapper/ListFileSnsEventAssistantLinkWrapper.client.tsx
@@ -1,40 +1,29 @@
 'use client';
 
 import Image from 'next/image';
+import { useParams } from 'next/navigation';
 
 import notFoundImage from '@assets/images/404/image.png';
 
+import useSnsEventList from '@api/sns-event-assistant/get/queries/useSnsEventList';
+
 import ListFileSnsEventAssistantLink from '@common/components/list-file/ListFileSnsEventAssistantLink/ListFileSnsEventAssistantLink.client';
 
-// 임시 데이터
-export const mockSnsEventLinks = [
-  {
-    snsEventId: 'link-001',
-    title: '7월 인스타그램 링크 이벤트',
-    updatedAt: '2025.07.20',
-    snsLink: 'https://instagram.com/haru_event_7july',
-  },
-  {
-    snsEventId: 'link-002',
-    title: '카카오톡 채널 친구추가 링크',
-    updatedAt: '2025.07.22',
-    snsLink: 'https://pf.kakao.com/_abcd1234',
-  },
-  {
-    snsEventId: 'link-003',
-    title: '페이스북 이벤트 페이지 링크',
-    updatedAt: '2025.07.28',
-    snsLink: 'https://facebook.com/events/haru_summer2025',
-  },
-];
-
 const ListFileSnsEventAssistantLinkWrapper = () => {
-  const hasLinks = mockSnsEventLinks.length > 0;
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const { extra: snsEvents } = useSnsEventList(workspaceId);
+  const hasLinks = !!snsEvents;
   return (
     <>
       {hasLinks ? (
-        mockSnsEventLinks.map((link) => (
-          <ListFileSnsEventAssistantLink key={link.snsEventId} {...link} />
+        snsEvents.snsEventList.map((event) => (
+          <ListFileSnsEventAssistantLink
+            key={event.snsEventId}
+            snsEventId={event.snsEventId}
+            snsLink={event.snsLink}
+            title={event.title}
+            updatedAt={`${event.updatedAt}`}
+          />
         ))
       ) : (
         <div className="w-658pxr h-440pxr relative">

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantLinkWrapper/ListFileSnsEventAssistantLinkWrapper.client.tsx
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantLinkWrapper/ListFileSnsEventAssistantLinkWrapper.client.tsx
@@ -9,6 +9,10 @@ import useSnsEventList from '@api/sns-event-assistant/get/queries/useSnsEventLis
 
 import ListFileSnsEventAssistantLink from '@common/components/list-file/ListFileSnsEventAssistantLink/ListFileSnsEventAssistantLink.client';
 
+/*
+ * ListFileSnsEventAssistantLinkWrapper 컴포넌트는 SNS 이벤트 링크 목록을 렌더링합니다.
+ * 만약 링크가 없다면 404 이미지를 보여줍니다.
+ */
 const ListFileSnsEventAssistantLinkWrapper = () => {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { extra: snsEvents } = useSnsEventList(workspaceId);

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantListWrapper/ListFileSnsEventAssistantListWrapper.client.tsx
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantListWrapper/ListFileSnsEventAssistantListWrapper.client.tsx
@@ -13,6 +13,10 @@ import ListHeader from '@common/components/list-file/ListHeader/ListHeader.serve
 
 import ListFileSnsEventAssistantWrapper from '../ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.client';
 
+/**
+ * SNS 이벤트 어시스턴트 파일 목록 전체 부분을 표시하는 컴포넌트입니다.
+ * Check 모드 시 삭제 버튼을 표시합니다.
+ */
 const ListFileSnsEventAssistantListWrapper = () => {
   const { isCheckedMode } = useSnsEventAssistantInfo();
   const { workspaceId } = useParams<{ workspaceId: string }>();

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantListWrapper/ListFileSnsEventAssistantListWrapper.client.tsx
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantListWrapper/ListFileSnsEventAssistantListWrapper.client.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
-
-import useDeleteSnsEventMutation from '@api/sns-event-assistant/delete/mutations/useDeleteSnsEventMutation';
+import { useParams, useRouter } from 'next/navigation';
 
 import { FileType } from '@common/types/file-type.enum';
+
+import { ROUTES } from '@common/constants/routes.constants';
+
+import { useSnsEventAssistantInfo } from '@common/hooks/stores/useSnsEventAssistantStore';
 
 import ListDeleteButton from '@common/components/list-file/ListDeleteButton/ListDeleteButton.client';
 import ListHeader from '@common/components/list-file/ListHeader/ListHeader.server';
@@ -12,55 +14,12 @@ import ListHeader from '@common/components/list-file/ListHeader/ListHeader.serve
 import ListFileSnsEventAssistantWrapper from '../ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.client';
 
 const ListFileSnsEventAssistantListWrapper = () => {
-  const [isCheckedMode, setIsCheckMode] = useState<boolean>(true);
-  const [checkedList, setCheckedList] = useState<string[]>([]);
-  const { mutate } = useDeleteSnsEventMutation();
-  // 화면 갱신 해야 함 - create가 안되서 일단 보류...
-  // store tankquery 사용 예정
+  const { isCheckedMode } = useSnsEventAssistantInfo();
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const router = useRouter();
   const handleDelete = () => {
-    if (checkedList.length === 0) return;
-
-    const successfullyDeletedIds: string[] = [];
-    let pendingDeletions = checkedList.length;
-
-    checkedList.forEach((snsEventId) => {
-      mutate(
-        { snsEventId },
-        {
-          onSuccess: () => {
-            successfullyDeletedIds.push(snsEventId);
-            pendingDeletions--;
-
-            if (pendingDeletions === 0) {
-              const newCheckedList = checkedList.filter(
-                (id) => !successfullyDeletedIds.includes(id),
-              );
-
-              setCheckedList(newCheckedList);
-
-              if (newCheckedList.length === 0) {
-                setIsCheckMode(false);
-              }
-            }
-          },
-          onError: (error) => {
-            console.error(`Deletion of ${snsEventId} failed:`, error);
-            pendingDeletions--;
-            if (pendingDeletions === 0) {
-              const newCheckedList = checkedList.filter(
-                (id) => !successfullyDeletedIds.includes(id),
-              );
-              setCheckedList(newCheckedList);
-              if (newCheckedList.length === 0) {
-                setIsCheckMode(false);
-              }
-            }
-          },
-        },
-      );
-    });
+    router.push(ROUTES.SNS_EVENT_ASSISTANT.DELETE(workspaceId));
   };
-
   return (
     <>
       {!isCheckedMode ? (
@@ -68,16 +27,11 @@ const ListFileSnsEventAssistantListWrapper = () => {
           <ListHeader fileType={FileType.SNS_EVENT_ASSISTANT} />
         </div>
       ) : (
-        <div className="mt-7pxr w-full">
+        <div className="pb-10pxr mt-7pxr mb-9pxr border-b-stroke-200 w-full border-b">
           <ListDeleteButton onClick={handleDelete} />
-          <div className="mt-8pxr mb-9pxr h-1pxr w-full bg-[#E6E9EF]" />
         </div>
       )}
-      <ListFileSnsEventAssistantWrapper
-        checkedList={checkedList}
-        onCheckModeToggle={setIsCheckMode}
-        onCheckedListToggle={setCheckedList}
-      />
+      <ListFileSnsEventAssistantWrapper />
     </>
   );
 };

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.client.tsx
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.client.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 
@@ -9,32 +7,32 @@ import notFoundImage from '@assets/images/404/image.png';
 
 import useSnsEventList from '@api/sns-event-assistant/get/queries/useSnsEventList';
 
+import {
+  useSnsEventAssistantActions,
+  useSnsEventAssistantInfo,
+} from '@common/hooks/stores/useSnsEventAssistantStore';
+
 import ListFileSnsEventAssistant from '@common/components/list-file/ListFileSnsEventAssistant/ListFileSnsEventAssistant.client';
 
-import { ListFileSnsEventAssistantWrapperProps } from './ListFileSnsEventAssistantWrapper.types';
-
-const ListFileSnsEventAssistantWrapper = ({
-  checkedList,
-  onCheckModeToggle,
-  onCheckedListToggle,
-}: ListFileSnsEventAssistantWrapperProps) => {
+const ListFileSnsEventAssistantWrapper = () => {
   const { workspaceId } = useParams<{ workspaceId: string }>();
-  const { extra } = useSnsEventList(workspaceId);
-  const [isCheckMode, setIsCheckMode] = useState(false);
-  const hasLists = !!extra?.snsEventList;
+  const { setCheckedList, setIsCheckedMode } = useSnsEventAssistantActions();
+  const { checkedList, isCheckedMode } = useSnsEventAssistantInfo();
+  const { extra: snsEvent } = useSnsEventList(workspaceId);
+  const hasLists = !!snsEvent?.snsEventList;
   const handleCheckToggle = (id: string) => {
     if (checkedList.includes(id)) {
       const newCheckedList = checkedList.filter((checkedId) => checkedId !== id);
-      onCheckedListToggle?.(newCheckedList);
+      setCheckedList(newCheckedList);
 
       if (newCheckedList.length === 0) {
-        setIsCheckMode(false);
+        setIsCheckedMode(false);
       }
     } else {
       const newCheckedList = [...checkedList, id];
-      onCheckedListToggle?.(newCheckedList);
+      setCheckedList(newCheckedList);
       if (newCheckedList.length === 1) {
-        setIsCheckMode(true);
+        setIsCheckedMode(true);
       }
     }
   };
@@ -43,23 +41,15 @@ const ListFileSnsEventAssistantWrapper = ({
     return checkedList.includes(id);
   };
 
-  useEffect(() => {
-    onCheckModeToggle?.(isCheckMode);
-  }, [isCheckMode, onCheckModeToggle]);
-
-  useEffect(() => {
-    onCheckedListToggle?.(checkedList);
-  }, [checkedList, onCheckedListToggle]);
-
   return (
     <>
       {hasLists ? (
-        extra?.snsEventList.map((list) => (
+        snsEvent?.snsEventList.map((list) => (
           <ListFileSnsEventAssistant
             key={list.snsEventId}
             {...list}
             isChecked={isChecked(list.snsEventId)}
-            isCheckMode={isCheckMode}
+            isCheckMode={isCheckedMode}
             onCheckToggle={handleCheckToggle}
           />
         ))

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.client.tsx
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.client.tsx
@@ -14,6 +14,10 @@ import {
 
 import ListFileSnsEventAssistant from '@common/components/list-file/ListFileSnsEventAssistant/ListFileSnsEventAssistant.client';
 
+/**
+ * SNS 이벤트 어시스턴트 파일 목록을 표시하는 컴포넌트입니다.
+ * 체크 모드에서 각 SNS 이벤트 항목을 체크할 수 있습니다.
+ */
 const ListFileSnsEventAssistantWrapper = () => {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { setCheckedList, setIsCheckedMode } = useSnsEventAssistantActions();

--- a/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.types.ts
+++ b/src/features/sns-event-assistant/components/list-file-wrapper/ListFileSnsEventAssistantWrapper/ListFileSnsEventAssistantWrapper.types.ts
@@ -1,5 +1,0 @@
-export interface ListFileSnsEventAssistantWrapperProps {
-  checkedList: string[];
-  onCheckModeToggle?: (isCheckMode: boolean) => void;
-  onCheckedListToggle?: (id: string[]) => void;
-}

--- a/src/features/sns-event-assistant/components/modal-client/DeleteEventModalClient/DeleteEventModalClient.tsx
+++ b/src/features/sns-event-assistant/components/modal-client/DeleteEventModalClient/DeleteEventModalClient.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+
+import useDeleteSnsEventMutation from '@api/sns-event-assistant/delete/mutations/useDeleteSnsEventMutation';
+
+import {
+  useSnsEventAssistantActions,
+  useSnsEventAssistantInfo,
+} from '@common/hooks/stores/useSnsEventAssistantStore';
+
+import DeleteModal from '@common/components/modals/DeleteModal/DeleteModal.client';
+import { DeleteModalType } from '@common/components/modals/DeleteModal/DeleteModal.types';
+
+import ModalLayout from '@/common/components/layouts/ModalLayout/ModalLayout.client';
+
+const DeleteEventModalClient = () => {
+  const router = useRouter();
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const { checkedList } = useSnsEventAssistantInfo();
+  const { setCheckedList, setIsCheckedMode } = useSnsEventAssistantActions();
+  const { mutate, isPending } = useDeleteSnsEventMutation(workspaceId);
+
+  const handleClose = () => {
+    router.back();
+  };
+
+  const handleDelete = () => {
+    if (checkedList.length === 0) return;
+    setCheckedList([]);
+    setIsCheckedMode(false);
+    checkedList.forEach((snsEventId) => {
+      mutate(
+        { snsEventId },
+        {
+          onSuccess: () => {
+            router.back();
+          },
+          onError: (error) => {
+            console.error(`Deletion of ${snsEventId} failed:`, error);
+            setCheckedList([...checkedList, snsEventId]);
+            setIsCheckedMode(true);
+          },
+        },
+      );
+    });
+  };
+
+  return (
+    <ModalLayout>
+      <DeleteModal
+        modalType={DeleteModalType.DELETE_EVENT}
+        onClose={handleClose}
+        onAbort={handleClose}
+        onProceed={handleDelete}
+        cancelBtnDisabled={isPending}
+        deleteBtnDisabled={isPending}
+        loading={isPending}
+        loadingText="삭제 중..."
+      />
+    </ModalLayout>
+  );
+};
+
+export default DeleteEventModalClient;

--- a/src/features/sns-event-assistant/components/modal-client/DownLoadModalClient/DownloadModalClient.tsx
+++ b/src/features/sns-event-assistant/components/modal-client/DownLoadModalClient/DownloadModalClient.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+
+import useCreateSnsEventDownloadMutation from '@api/sns-event-assistant/post/mutations/useCreateSnsEventDownloadMutation';
+
+// import useSnsEventListDownload from '@api/sns-event-assistant/get/queries/useSnsEventListDownload';
+
+import { DownloadFormat, SnsEventAssistantListType } from '@common/types/download.enum.types';
+
+import DownloadModal from '@common/components/modals/DownloadModal/DownloadModal.client';
+
+import ModalLayout from '@/common/components/layouts/ModalLayout/ModalLayout.client';
+
+const DownloadModalClient = () => {
+  const router = useRouter();
+  const { snsEventId } = useParams<{ snsEventId: string }>();
+  const searchParams = useSearchParams();
+  const listType =
+    (searchParams.get('type') as SnsEventAssistantListType) ||
+    SnsEventAssistantListType.PARTICIPANT;
+  // 현재 POST로 되어있어서 추후에 GET으로 변경 필요
+  // const [enabled, setEnabled] = useState(false);
+  // useSnsEventListDownload(
+  //   {
+  //     snsEventId,
+  //     listType,
+  //     format,
+  //   },
+  //   {
+  //     enabled,
+  //     onSuccess: (data) => {
+  //       window.open(data.downloadLink, '_blank');
+  //       setEnabled(false);
+  //     },
+  //     onError: (error) => {
+  //       alert(`다운로드에 실패했습니다: ${error.message}`);
+  //       setEnabled(false);
+  //       console.log(snsEventId, listType, format);
+  //     },
+  //   },
+  // );
+  const { mutate: snsEvent } = useCreateSnsEventDownloadMutation();
+
+  const handleDownload = (format: DownloadFormat) => {
+    snsEvent(
+      {
+        snsEventId,
+        format,
+        listType,
+      },
+      {
+        onSuccess: (data) => {
+          window.open(data.result.downloadLink, '_blank');
+        },
+        onError: (error) => {
+          alert(`다운로드에 실패했습니다: ${error.message}`);
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    router.back();
+  };
+
+  return (
+    <ModalLayout>
+      <DownloadModal
+        onClose={handleClose}
+        onPdfDownload={() => handleDownload(DownloadFormat.PDF)}
+        onWordDownload={() => handleDownload(DownloadFormat.DOCX)}
+      />
+    </ModalLayout>
+  );
+};
+
+export default DownloadModalClient;

--- a/src/features/sns-event-assistant/components/modal-client/NewEventModalClient/NewEventModalClient.tsx
+++ b/src/features/sns-event-assistant/components/modal-client/NewEventModalClient/NewEventModalClient.tsx
@@ -2,24 +2,22 @@
 
 import { useParams, useRouter } from 'next/navigation';
 
+import { ROUTES } from '@common/constants/routes.constants';
+
 import CreateNewEventModal from '@common/components/modals/CreateNewEventModal/CreateNewEventModal.client';
 
 import ModalLayout from '@/common/components/layouts/ModalLayout/ModalLayout.client';
 
 const NewEventModalClient = () => {
   const router = useRouter();
-  const { workspaceId } = useParams();
+  const { workspaceId } = useParams<{ workspaceId: string }>();
 
   const handleClose = () => {
     router.back();
   };
 
   const handleNextStep = () => {
-    if (workspaceId) {
-      router.push(`/workspace/${workspaceId}/sns-event-assistant/creating-event`);
-    } else {
-      console.error('workspaceId가 없습니다.');
-    }
+    router.push(ROUTES.SNS_EVENT_ASSISTANT.CREATE(workspaceId));
   };
 
   return (


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.

- Issue #284 #283 

## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

## SNS 이벤트 어시스턴트

- [x]  복사 버튼 사용 및 토스트 띄우기
- [x]  인스타 링크 연결 기능
- [x]  참여자 수, 당첨자 수 적용 확인

### List File Wrapper

- [x]  useSnsEventList Zustand에 추가
- [x]  useDeleteSnsEventMutation Query Key 초기화 넣기
- [x]  CheckMode 삭제 후 false로 변경
- [x]  SNS 이벤트 링크 임시 데이터 삭제 및 Zustand 값 추가

### Create New Event Modal

- [x]  Zustand 값 초기화 구문
- [x]  is 상태 항상 true 반환 수정 (옵셔널 확인하고 작성하기)

### New Event Modal Client

- [x]  router.push를 키 값으로 관리

### Create Event Modal Client

- [x]  useCreateSnsEventMutation Query Key 초기화 넣기
- [x]  router.push를 키 값으로 관리
- [x]  모달이 남은 상태에서 이동하는 것 수정

### Delete Event Modal

- [x]  바로 삭제 되는 방식 → 모달 생성으로 변경

### SNS 이벤트 어시스턴트 상세

- [x]  Input Title 수정 안되는 버그 수정
- [x]  더미 데이터 → api 사용
- [x]  데이터 분리 후 왼쪽 오른쪽 분배 (참여자 리스트 / 당첨자 리스트)
- [x]  상단 토글 버튼 숫자 값 적용
- [x]  SNS 링크 칸 외부 링크 연결
- [x] 날짜 오류 수정

### Download Event Modal

- [x]  추가 및 API 연결

## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.

-

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

- 현재 다운로드가 POST로 되어있어 나중에 벡엔드 수정 시 바꿀 예정입니다.

## 📝 Checklist

- [ ] Reviewer를 추가했나요?
- [ ] Convention을 준수했나요?
