### PR TITLE
[Fix] CTA 버튼이 가로 영역을 전부 차지하던 문제 해결

### DIFF
--- a/src/common/components/cta/TextCtaWrapper/TextCtaWrapper.server.tsx
+++ b/src/common/components/cta/TextCtaWrapper/TextCtaWrapper.server.tsx
@@ -18,7 +18,7 @@ const TextCtaWrapper = ({ fileType, workspaceId }: TextCtaWrapperProps) => {
   }
 
   return href ? (
-    <Link href={href}>
+    <Link href={href} className="inline-block w-fit">
       <TextCta type={fileType} disabled={false} />
     </Link>
   ) : (


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.

- Issue #275 

## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

- `Link` 태그는 `a` 태그로 렌더링되며, 이는 `display: inline` 속성을 가지고, 이는 자동으로 stretch를 하기 떄문에 강제로 `inline-block` 속성을 줘서 필요한 넓이만큼만 가지도록 변경

## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.

-

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

-

## 📝 Checklist

- [ ] Reviewer를 추가했나요?
- [ ] Convention을 준수했나요?
