### PR TITLE
[Feat] 마감 전에 Chart Survery 마감일 이전 안내 표시 & Title 낙관적 업데이트 동작 & Tab 영역이 각 섹션 컴포넌트의 관할이 되도록 변경

### DIFF
--- a/src/features/team-mood-tracker/components/mood-reports/answer-section/TeamMoodAnswerChartSection/TeamMoodAnswerChartSection.client.tsx
+++ b/src/features/team-mood-tracker/components/mood-reports/answer-section/TeamMoodAnswerChartSection/TeamMoodAnswerChartSection.client.tsx
@@ -10,57 +10,87 @@ import { TeamMoodTrackerSurveyQuestionType } from '@features/team-mood-tracker/c
 
 import { filterSafeResponseList } from '@features/team-mood-tracker/utils/safe-response-list.utils';
 
+import TeamMoodReportTab from '../../report-section/TeamMoodReportTab/TeamMoodReportTab.client';
+import { TeamMoodReportTabType } from '../../report-section/TeamMoodReportTab/TeamMoodReportTab.types';
+import TeamMoodAnswerNoneContentSection from '../TeamMoodAnswerNoneContentSection/TeamMoodAnswerNoneContentSection.server';
 import { TeamMoodAnswerChartSectionProps } from './TeamMoodAnswerChartSection.types';
 
 const PIE_CHART_COLORS = ['#E65787', '#5E8BFF', '#FFD66C', '#84D1B6', '#B28DFF']; // 임시 색상
 
-const TeamMoodAnswerChartSection = ({ moodTrackerHashedId }: TeamMoodAnswerChartSectionProps) => {
+const TeamMoodAnswerChartSection = ({
+  moodTrackerHashedId,
+  respondentsNum,
+}: TeamMoodAnswerChartSectionProps) => {
   const { data: surveyResponse, isFetching: isSurveyFetching } =
     useViewSurveyResponse(moodTrackerHashedId);
 
   const responses = filterSafeResponseList(surveyResponse?.responseList);
 
   return (
-    <div className="w-668pxr gap-y-24pxr mx-auto flex flex-col">
-      {responses.map((response) => {
-        // 4. case의 문자열을 enum으로 변경하여 안정성을 높입니다.
-        switch (response.type) {
-          case TeamMoodTrackerSurveyQuestionType.MULTIPLE_CHOICE: {
-            const chartData = {
-              labels: response.multipleChoiceResponseList.map((item) => item.content),
-              values: response.multipleChoiceResponseList.map((item) => item.selectedNum),
-              colors: PIE_CHART_COLORS.slice(0, response.multipleChoiceResponseList.length),
-            };
-            return (
-              <PieChart key={response.questionId} title={response.questionTitle} data={chartData} />
-            );
-          }
+    <>
+      {/* 탭 컴포넌트를 항상 렌더링합니다. */}
+      <div className="border-stroke-200 mb-14pxr w-full border-b border-solid bg-white">
+        <div className="w-668pxr mx-auto">
+          <TeamMoodReportTab
+            current={TeamMoodReportTabType.ANSWER_SUMMARY}
+            counts={{
+              [TeamMoodReportTabType.TEAM_MOOD_REPORT]: 0,
+              [TeamMoodReportTabType.ANSWER_SUMMARY]: respondentsNum,
+              [TeamMoodReportTabType.SURVEY_LIST]: 0,
+            }}
+          />
+        </div>
+      </div>
 
-          case TeamMoodTrackerSurveyQuestionType.CHECKBOX_CHOICE: {
-            const chartData = {
-              labels: response.checkboxChoiceResponseList.map((item) => item.content),
-              values: response.checkboxChoiceResponseList.map((item) => item.selectedNum),
-            };
-
-            return (
-              <BarChart key={response.questionId} title={response.questionTitle} data={chartData} />
-            );
-          }
-
-          case TeamMoodTrackerSurveyQuestionType.SUBJECTIVE:
-            return (
-              <SubjectiveAnswers
-                key={response.questionId}
-                title={response.questionTitle}
-                answers={response.subjectiveResponseList}
-              />
-            );
-
-          default:
-            return null;
-        }
-      })}
-    </div>
+      {/* 2. 컨텐츠 영역만 로딩/데이터 없음/데이터 있음을 기준으로 조건부 렌더링합니다. */}
+      {!responses || responses.length === 0 ? (
+        <TeamMoodAnswerNoneContentSection />
+      ) : (
+        <div className="w-668pxr gap-y-24pxr mx-auto flex flex-col">
+          {responses.map((response) => {
+            switch (response.type) {
+              case TeamMoodTrackerSurveyQuestionType.MULTIPLE_CHOICE: {
+                const chartData = {
+                  labels: response.multipleChoiceResponseList.map((item) => item.content),
+                  values: response.multipleChoiceResponseList.map((item) => item.selectedNum),
+                  colors: PIE_CHART_COLORS.slice(0, response.multipleChoiceResponseList.length),
+                };
+                return (
+                  <PieChart
+                    key={response.questionId}
+                    title={response.questionTitle}
+                    data={chartData}
+                  />
+                );
+              }
+              case TeamMoodTrackerSurveyQuestionType.CHECKBOX_CHOICE: {
+                const chartData = {
+                  labels: response.checkboxChoiceResponseList.map((item) => item.content),
+                  values: response.checkboxChoiceResponseList.map((item) => item.selectedNum),
+                };
+                return (
+                  <BarChart
+                    key={response.questionId}
+                    title={response.questionTitle}
+                    data={chartData}
+                  />
+                );
+              }
+              case TeamMoodTrackerSurveyQuestionType.SUBJECTIVE:
+                return (
+                  <SubjectiveAnswers
+                    key={response.questionId}
+                    title={response.questionTitle}
+                    answers={response.subjectiveResponseList}
+                  />
+                );
+              default:
+                return null;
+            }
+          })}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/features/team-mood-tracker/components/mood-reports/answer-section/TeamMoodAnswerChartSection/TeamMoodAnswerChartSection.types.ts
+++ b/src/features/team-mood-tracker/components/mood-reports/answer-section/TeamMoodAnswerChartSection/TeamMoodAnswerChartSection.types.ts
@@ -1,4 +1,5 @@
 export interface TeamMoodAnswerChartSectionProps {
   // responses: SurveyQuestion[];
   moodTrackerHashedId: string;
+  respondentsNum: number;
 }

--- a/src/features/team-mood-tracker/components/mood-reports/answer-section/TeamMoodAnswerNoneContentSection/TeamMoodAnswerNoneContentSection.server.tsx
+++ b/src/features/team-mood-tracker/components/mood-reports/answer-section/TeamMoodAnswerNoneContentSection/TeamMoodAnswerNoneContentSection.server.tsx
@@ -1,0 +1,9 @@
+const TeamMoodAnswerNoneContentSection = () => {
+  return (
+    <div className="mt-230pxr text-b2-rg flex items-center justify-center text-center whitespace-pre-line text-gray-300">
+      {`아직 설문이 모두 제출되지 않았어요!\n 설문 마감 후, 팀원들의 응답 내용이 차트의 형태로 이곳에 표시돼요.`}
+    </div>
+  );
+};
+
+export default TeamMoodAnswerNoneContentSection;

--- a/src/features/team-mood-tracker/components/mood-reports/question-section/TeamMoodSurveyQuestionSection/TeamMoodSurveyQuestionSection.client.tsx
+++ b/src/features/team-mood-tracker/components/mood-reports/question-section/TeamMoodSurveyQuestionSection/TeamMoodSurveyQuestionSection.client.tsx
@@ -13,57 +13,76 @@ import { TeamMoodTrackerSurveyQuestionType } from '@features/team-mood-tracker/c
 
 import TeamMoodTrackerFilePageSectionSkeleton from '@features/team-mood-tracker/components/skeletons/TeamMoodTrackerFilePageSectionSkeleton/TeamMoodTrackerFilePageSectionSkeleton.server';
 
-interface TeamMoodSurveyQuestionSectionProps {
-  moodTrackerHashedId: string;
-}
+import TeamMoodReportTab from '../../report-section/TeamMoodReportTab/TeamMoodReportTab.client';
+import { TeamMoodReportTabType } from '../../report-section/TeamMoodReportTab/TeamMoodReportTab.types';
+import { TeamMoodSurveyQuestionSectionProps } from './TeamMoodSurveyQuestionSection.types';
+
 const TeamMoodSurveyQuestionSection = ({
   moodTrackerHashedId,
+  respondentsNum,
 }: TeamMoodSurveyQuestionSectionProps) => {
   const { data, isLoading } = useViewSurveyQuestion(moodTrackerHashedId);
 
-  if (!data || isLoading) {
-    console.log('[TEAM_MOOD_TRACKER] 설문 문항 로딩 중', moodTrackerHashedId, data, isLoading);
-    return <TeamMoodTrackerFilePageSectionSkeleton />;
-  }
-
   return (
-    <div className="w-668pxr mx-auto">
-      <SurveyInfo title={data.title} content={data.description} />
-      <div className="gap-y-14pxr mt-15pxr flex flex-col">
-        {/* TODO: type 통일 필요 .. assertion은 사용되서는 안됩니다 ㅠㅠ */}
-        {data.questionList.map((question) => {
-          let options: string[] = [];
-
-          // switch 문을 사용해 question.type에 따라 타입을 좁힙니다.
-          switch (question.type) {
-            case TeamMoodTrackerSurveyQuestionType.MULTIPLE_CHOICE:
-              // 이 블록 안에서 question은 MULTIPLE_CHOICE 타입으로 확정됩니다.
-              options = question.multipleChoiceList.map((choice) => choice.content);
-              break; // case마다 break를 잊지 마세요.
-
-            case TeamMoodTrackerSurveyQuestionType.CHECKBOX_CHOICE:
-              // 이 블록 안에서 question은 CHECKBOX_CHOICE 타입으로 확정됩니다.
-              options = question.checkboxChoiceList.map((choice) => choice.content);
-              break;
-
-            case TeamMoodTrackerSurveyQuestionType.SUBJECTIVE:
-              // 이 블록 안에서 question은 SUBJECTIVE 타입으로 확정됩니다.
-              // 주관식은 선택지가 없으므로 빈 배열을 할당합니다.
-              options = [];
-              break;
-          }
-          return (
-            <InputSurveyQuestion
-              key={question.questionId}
-              questionTitle={question.questionTitle}
-              questionType={question.type as unknown as InputSurveyQuestionType}
-              multipleOrCheckboxOptions={options}
-              surveyComponentUsingSituation={SurveySituation.VIEW_SURVEY_QUESTIONS}
-            />
-          );
-        })}
+    <>
+      {/* 탭 컴포넌트를 항상 렌더링합니다. */}
+      <div className="border-stroke-200 mb-14pxr w-full border-b border-solid bg-white">
+        <div className="w-668pxr mx-auto">
+          <TeamMoodReportTab
+            current={TeamMoodReportTabType.SURVEY_LIST}
+            counts={{
+              [TeamMoodReportTabType.TEAM_MOOD_REPORT]: 0,
+              [TeamMoodReportTabType.ANSWER_SUMMARY]: respondentsNum,
+              [TeamMoodReportTabType.SURVEY_LIST]: 0,
+            }}
+            // handleLinkClick={handleLinkClick} -> 구현 되어 있지 않음
+          />
+        </div>
       </div>
-    </div>
+
+      {/* 컨텐츠 영역만 로딩/데이터 없음/데이터 있음을 기준으로 조건부 렌더링합니다. */}
+      {isLoading || !data ? (
+        <TeamMoodTrackerFilePageSectionSkeleton />
+      ) : (
+        <div className="w-668pxr mx-auto">
+          <SurveyInfo title={data.title} content={data.description} />
+          <div className="gap-y-14pxr mt-15pxr flex flex-col">
+            {/* TODO: type 통일 필요 .. assertion은 사용되서는 안됩니다 ㅠㅠ */}
+            {data.questionList.map((question) => {
+              let options: string[] = [];
+
+              // switch 문을 사용해 question.type에 따라 타입을 좁힙니다.
+              switch (question.type) {
+                case TeamMoodTrackerSurveyQuestionType.MULTIPLE_CHOICE:
+                  // 이 블록 안에서 question은 MULTIPLE_CHOICE 타입으로 확정됩니다.
+                  options = question.multipleChoiceList.map((choice) => choice.content);
+                  break; // case마다 break를 잊지 마세요.
+
+                case TeamMoodTrackerSurveyQuestionType.CHECKBOX_CHOICE:
+                  // 이 블록 안에서 question은 CHECKBOX_CHOICE 타입으로 확정됩니다.
+                  options = question.checkboxChoiceList.map((choice) => choice.content);
+                  break;
+
+                case TeamMoodTrackerSurveyQuestionType.SUBJECTIVE:
+                  // 이 블록 안에서 question은 SUBJECTIVE 타입으로 확정됩니다.
+                  // 주관식은 선택지가 없으므로 빈 배열을 할당합니다.
+                  options = [];
+                  break;
+              }
+              return (
+                <InputSurveyQuestion
+                  key={question.questionId}
+                  questionTitle={question.questionTitle}
+                  questionType={question.type as unknown as InputSurveyQuestionType}
+                  multipleOrCheckboxOptions={options}
+                  surveyComponentUsingSituation={SurveySituation.VIEW_SURVEY_QUESTIONS}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/features/team-mood-tracker/components/mood-reports/question-section/TeamMoodSurveyQuestionSection/TeamMoodSurveyQuestionSection.types.ts
+++ b/src/features/team-mood-tracker/components/mood-reports/question-section/TeamMoodSurveyQuestionSection/TeamMoodSurveyQuestionSection.types.ts
@@ -1,0 +1,4 @@
+export interface TeamMoodSurveyQuestionSectionProps {
+  moodTrackerHashedId: string;
+  respondentsNum: number;
+}

--- a/src/features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportContentSection/TeamMoodReportContentSection.client.tsx
+++ b/src/features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportContentSection/TeamMoodReportContentSection.client.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
+import { TEAM_MOOD_TRACKER_PAGE_ROUTES } from '@api/team-mood-tracker/end-point.constants';
 import { useViewReportResponse } from '@api/team-mood-tracker/get/queries/useViewReportResponse';
 
 import { FileType } from '@common/types/file-type.enum';
@@ -15,12 +16,16 @@ import { useTeamMoodToastActions } from '@features/team-mood-tracker/hooks/store
 
 import TeamMoodReportNoneContentSection from '@features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportNoneContentSection/TeamMoodReportNoneContentSection.server';
 
+import TeamMoodReportTab from '../TeamMoodReportTab/TeamMoodReportTab.client';
+import { TeamMoodReportTabType } from '../TeamMoodReportTab/TeamMoodReportTab.types';
 import { TeamMoodReportContentSectionProps } from './TeamMoodReportContentSection.types';
 
 const TeamMoodReportContentSection = ({
   moodTrackerHashedId,
-  setCopyHandler,
+  workspaceId,
+  respondentsNum,
 }: TeamMoodReportContentSectionProps) => {
+  const router = useRouter();
   const { data: reportResponse, isFetching: isReportFetching } =
     useViewReportResponse(moodTrackerHashedId);
 
@@ -28,49 +33,56 @@ const TeamMoodReportContentSection = ({
 
   const { showCopyToast } = useTeamMoodToastActions();
 
-  // 부모 컴포넌트로 복사 버튼 관련 로직을 전달합니다.
-  useEffect(() => {
-    if (reportResponse) {
-      const handleCopyClick = async () => {
-        const reportContent = reportResponse.report;
-
-        if (!reportContent || reportContent.trim() === '') {
-          showCopyToast({ type: TeamMoodTrackerToastType.COPY_EMPTY });
-          return;
-        }
-
-        try {
-          await navigator.clipboard.writeText(reportContent);
-          showCopyToast({ type: TeamMoodTrackerToastType.COPY_SUCCESS });
-        } catch (err) {
-          console.error('클립보드 복사 실패:', err);
-          showCopyToast({ type: TeamMoodTrackerToastType.COPY_EMPTY });
-        }
-      };
-
-      setCopyHandler(handleCopyClick);
+  const handleCopyClick = async () => {
+    if (!report || report.trim() === '') {
+      showCopyToast({ type: TeamMoodTrackerToastType.COPY_EMPTY });
+      return;
     }
-  }, []);
+    try {
+      await navigator.clipboard.writeText(report);
+      showCopyToast({ type: TeamMoodTrackerToastType.COPY_SUCCESS });
+    } catch (err) {
+      console.error('클립보드 복사 실패:', err);
+      showCopyToast({ type: TeamMoodTrackerToastType.COPY_EMPTY });
+    }
+  };
 
-  if (!suggestionList || !report || (report && report.trim() === '')) {
-    return <TeamMoodReportNoneContentSection />;
-  }
-
-  // TODO: 스켈레톤으로 변경
-  if (isReportFetching) {
-    return <div>Loading ... </div>;
-  }
+  const handleDownloadClick = () => {
+    router.push(TEAM_MOOD_TRACKER_PAGE_ROUTES.DOWNLOAD(workspaceId, moodTrackerHashedId));
+  };
 
   return (
-    <div className="mx-auto">
-      <div className="mb-2pxr">
-        <SurveyInSite title="HaRu의 제안" items={suggestionList} />
+    <>
+      {/* 로딩 중이거나 데이터가 없어도 탭 UI는 일관되게 보여줍니다. */}
+      <div className="border-stroke-200 mb-14pxr w-full border-b border-solid bg-white">
+        <div className="w-668pxr mx-auto">
+          <TeamMoodReportTab
+            current={TeamMoodReportTabType.TEAM_MOOD_REPORT}
+            counts={{
+              [TeamMoodReportTabType.TEAM_MOOD_REPORT]: 0,
+              [TeamMoodReportTabType.ANSWER_SUMMARY]: respondentsNum,
+              [TeamMoodReportTabType.SURVEY_LIST]: 0,
+            }}
+            handleCopyClick={handleCopyClick}
+            handleDownloadClick={handleDownloadClick}
+          />
+        </div>
       </div>
 
-      <div className="w-668pxr">
-        <MarkdownContent variant={FileType.TEAM_MOOD_TRACKER} content={report} />
-      </div>
-    </div>
+      {/* 컨텐츠 영역만 로딩/데이터 없음/데이터 있음을 기준으로 조건부 렌더링합니다. */}
+      {!suggestionList || !report || report.trim() === '' ? (
+        <TeamMoodReportNoneContentSection />
+      ) : (
+        <div className="mx-auto">
+          <div className="mb-2pxr">
+            <SurveyInSite title="HaRu의 제안" items={suggestionList} />
+          </div>
+          <div className="w-668pxr">
+            <MarkdownContent variant={FileType.TEAM_MOOD_TRACKER} content={report} />
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportContentSection/TeamMoodReportContentSection.types.ts
+++ b/src/features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportContentSection/TeamMoodReportContentSection.types.ts
@@ -1,6 +1,5 @@
-import { Dispatch, SetStateAction } from 'react';
-
 export interface TeamMoodReportContentSectionProps {
   moodTrackerHashedId: string;
-  setCopyHandler: Dispatch<SetStateAction<() => void>>;
+  workspaceId: string;
+  respondentsNum: number;
 }

--- a/src/features/team-mood-tracker/components/page-wrapper/TeamMoodTrackerDetailPage/TeamMoodTrackerDetailPage.client.tsx
+++ b/src/features/team-mood-tracker/components/page-wrapper/TeamMoodTrackerDetailPage/TeamMoodTrackerDetailPage.client.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
 
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
-
-import { TEAM_MOOD_TRACKER_PAGE_ROUTES } from '@api/team-mood-tracker/end-point.constants';
 import { useSurveyBasicInfo } from '@api/team-mood-tracker/get/queries/useSurveyBasicInfo';
 
 import { GnbSection } from '@common/types/gnbs.types';
@@ -16,7 +13,6 @@ import TeamMoodAnswerChartSection from '@features/team-mood-tracker/components/m
 import TeamMoodTrackerDetailPageTitle from '@features/team-mood-tracker/components/mood-reports/common/TeamMoodTrackerDetailPageTitle/TeamMoodTrackerDetailPageTitle.client';
 import TeamMoodSurveyQuestionSection from '@features/team-mood-tracker/components/mood-reports/question-section/TeamMoodSurveyQuestionSection/TeamMoodSurveyQuestionSection.client';
 import TeamMoodReportContentSection from '@features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportContentSection/TeamMoodReportContentSection.client';
-import TeamMoodReportTab from '@features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportTab/TeamMoodReportTab.client';
 import { TeamMoodReportTabType } from '@features/team-mood-tracker/components/mood-reports/report-section/TeamMoodReportTab/TeamMoodReportTab.types';
 import TeamMoodTrackerPageSkeleton from '@features/team-mood-tracker/components/skeletons/TeamMoodTrackerSkeleton/TeamMoodTrackerSkeleton';
 import TeamMoodToast from '@features/team-mood-tracker/components/toasts/TeamMoodToast/TeamMoodToast.client';
@@ -31,10 +27,6 @@ const TeamMoodTrackerDetailPage = () => {
   const workspaceId = params.workspaceId;
   const moodTrackerHashedId = params.moodTrackerHashedId;
 
-  const router = useRouter();
-
-  const [copyHandler, setCopyHandler] = useState<() => void>(() => () => {});
-
   /**
    * query string에서 현재 tab 정보를 가져옵니다.
    */
@@ -47,23 +39,30 @@ const TeamMoodTrackerDetailPage = () => {
 
   // TODO: skeleton은 tab 단위로 수정
 
-  const handleDownloadClick = () => {
-    router.push(TEAM_MOOD_TRACKER_PAGE_ROUTES.DOWNLOAD(workspaceId, moodTrackerHashedId));
-  };
-
   const renderTabContent = () => {
     switch (currentTab) {
       case TeamMoodReportTabType.TEAM_MOOD_REPORT:
         return (
           <TeamMoodReportContentSection
             moodTrackerHashedId={moodTrackerHashedId}
-            setCopyHandler={setCopyHandler}
+            workspaceId={workspaceId}
+            respondentsNum={surveyBasicInfo?.respondentsNum ?? 0}
           />
         );
       case TeamMoodReportTabType.ANSWER_SUMMARY:
-        return <TeamMoodAnswerChartSection moodTrackerHashedId={moodTrackerHashedId} />;
+        return (
+          <TeamMoodAnswerChartSection
+            moodTrackerHashedId={moodTrackerHashedId}
+            respondentsNum={surveyBasicInfo?.respondentsNum ?? 0}
+          />
+        );
       case TeamMoodReportTabType.SURVEY_LIST:
-        return <TeamMoodSurveyQuestionSection moodTrackerHashedId={moodTrackerHashedId} />;
+        return (
+          <TeamMoodSurveyQuestionSection
+            moodTrackerHashedId={moodTrackerHashedId}
+            respondentsNum={surveyBasicInfo?.respondentsNum ?? 0}
+          />
+        );
       default:
         return <div>알 수 없는 탭입니다.</div>;
     }
@@ -74,7 +73,7 @@ const TeamMoodTrackerDetailPage = () => {
     return <TeamMoodTrackerPageSkeleton />;
   }
 
-  const { title, creatorName, creatorId, updatedAt, respondentsNum } = surveyBasicInfo;
+  const { title, creatorName, creatorId, updatedAt } = surveyBasicInfo;
 
   return (
     <>
@@ -86,28 +85,14 @@ const TeamMoodTrackerDetailPage = () => {
           <TeamMoodToast />
         </div>
         {/* MAIN CONTENT */}
-        <div className="mt-24pxr mb-10pxr w-668pxr mx-auto flex-col">
+        <div className="mt-24pxr mx-auto">
           <TeamMoodTrackerDetailPageTitle
             moodTrackerHashedId={moodTrackerHashedId}
             surveyBasicInfo={surveyBasicInfo}
           />
-          <FileCreatedInfo name={creatorName} userId={creatorId} dateTime={updatedAt} />
         </div>
-        {/* 탭 영역 */}
-        {/* TODO: 이거 그냥 마음에 안들어서 바꾸고 싶어요 @kyeoungwoon */}
-        <div className="border-stroke-200 mb-14pxr w-full border-b border-solid bg-white">
-          <div className="w-668pxr mx-auto">
-            <TeamMoodReportTab
-              current={currentTab}
-              counts={{
-                [TeamMoodReportTabType.TEAM_MOOD_REPORT]: 0,
-                [TeamMoodReportTabType.ANSWER_SUMMARY]: respondentsNum,
-                [TeamMoodReportTabType.SURVEY_LIST]: 0,
-              }}
-              handleCopyClick={copyHandler}
-              handleDownloadClick={handleDownloadClick}
-            />
-          </div>
+        <div className="mb-10pxr w-668pxr mx-auto flex-col">
+          <FileCreatedInfo name={creatorName} userId={creatorId} dateTime={updatedAt} />
         </div>
         {renderTabContent()}
       </div>


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.

- Issue #327 #328 #329 #336 

## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

- 마감전 Chart Survery 마감일 이전안내 표시
- Title 낙관적 업데이트 안 되는 문제
- 리포트 복사 로직 동작
-  팀 분위기 설문 리포트 조회 페이지에서 Tab 영역이 각 섹션 컴포넌트의 관할이 되도록 변경

## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.

-

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

-

## 📝 Checklist

- [ ] Reviewer를 추가했나요?
- [ ] Convention을 준수했나요?
